### PR TITLE
Fix release notes link for Xamarin.Forms

### DIFF
--- a/docs/xamarin-forms/TOC.md
+++ b/docs/xamarin-forms/TOC.md
@@ -266,7 +266,7 @@
 #### [Why doesn't the Visual Studio XAML designer work for Xamarin.Forms XAML files?](troubleshooting/questions/forms-xaml-designer.md)
 #### [Android build error: The "LinkAssemblies" task failed unexpectedly](troubleshooting/questions/android-linkassemblies-error.md)
 #### [Why does my Xamarin.Forms.Maps Android project fail with COMPILETODALVIK : UNEXPECTED TOP-LEVEL ERROR?](troubleshooting/questions/maps-compiletodalvik-error.md)
-## [Release Notes](https://developer.xamarin.com/releases/mac/)
+## [Release Notes](https://developer.xamarin.com/releases/xamarin-forms/)
 ## [Samples](samples/index.yml)
 ## [Creating Mobile Apps with Xamarin.Forms Book](creating-mobile-apps-xamarin-forms/index.md)
 ## [Enterprise Application Patterns eBook](enterprise-application-patterns/index.md)


### PR DESCRIPTION
Link in TOC previously pointed to release notes for mac. 