### PR TITLE
Fixed Xamarin Workbooks image url

### DIFF
--- a/docs/tools/index.yml
+++ b/docs/tools/index.yml
@@ -37,7 +37,7 @@ sections:
     - href: ~/tools/workbooks/index.md
       html: Learn C# and the Xamarin platform interactively.
       image:
-        src: https://review.docs.microsoft.com/en-us//media/illustrations/dynamics-resource-library.svg?branch=master
+        src: ~/media/illustrations/dynamics-resource-library.svg?branch=master
         href: ~/tools/workbooks/index.md
       title: Xamarin Workbooks
     - href: ~/tools/ios-simulator.md


### PR DESCRIPTION
Fixed wrong image URL for other languages, for example:
https://docs.microsoft.com/ru-ru/xamarin/#pivot=tools&panel=architecture1