### PR TITLE
Remove language around "Xamarin now being free".

### DIFF
--- a/docs/cross-platform/get-started/installation/windows.md
+++ b/docs/cross-platform/get-started/installation/windows.md
@@ -11,9 +11,7 @@ ms.date: 09/29/2017
 
 # Installing Xamarin in Visual Studio on Windows
 
-Because Xamarin is now included with all editions of Visual Studio at
-no extra cost and does not require a separate license, you can use the
-Visual Studio installer to download and install Xamarin tools.
+Xamarin is free to use and included in all editions of Visual Studio.
 
 <a name="requirements" />
 


### PR DESCRIPTION
This PR removes additional context around Xamarin now being free, as this change was made 2+ years ago. I don't think we need to bring this context into the docs, and just state that it's free and available in all editions of Visual Studio.