### PR TITLE
Update Mono uninstall commands

### DIFF
--- a/docs/cross-platform/get-started/installation/uninstalling-xamarin.md
+++ b/docs/cross-platform/get-started/installation/uninstalling-xamarin.md
@@ -77,6 +77,7 @@ To remove the Mono Framework from a machine, run the following commands in Termi
 ```bash
 sudo rm -rf /Library/Frameworks/Mono.framework
 sudo pkgutil --forget com.xamarin.mono-MDK.pkg
+sudo rm /etc/paths.d/mono-commands
 ```
 
 <a name="uninstallandroid" />


### PR DESCRIPTION
We drop an additional file in /etc/paths.d since Mono 4.4.1: http://www.mono-project.com/docs/about-mono/releases/4.4.1/#changes-in-the-osx-installation-package