### PR TITLE
Fixes to the Tools section

### DIFF
--- a/docs/tools/ios-simulator.md
+++ b/docs/tools/ios-simulator.md
@@ -22,7 +22,7 @@ Download the [installer](https://dl.xamarin.com/xamarin-simulator/Xamarin.Simula
 and install on your Windows computer. Visual Studio Tools for Xamarin should already be installed.
 
 > [!NOTE]
-> Using a remote iOS Simulator requires Visual Studio a networked Mac with Xamarin installed.
+> Using a remote iOS Simulator on Visual Studio requires a networked Mac with Xamarin installed.
 
 ## Getting Started
 

--- a/docs/tools/live-player/index.md
+++ b/docs/tools/live-player/index.md
@@ -16,8 +16,8 @@ Xamarin Live Player lets you make live edits to your app and have those changes 
 
 [![Xamarin Live Player: Code, Scan, Test](images/xamarin-live.png)](images/xamarin-live-sml.png#lightbox)
 
-1. Enable the *Xamarin Live Player* in **Preferences**, then select from the **Devices** list.
-2. Debug or run, and then scan the QRCodeto pair your device.
+1. Enable the *Xamarin Live Player* in **Preferences**, then select your device from the **Devices** list.
+2. Debug or run, and then scan the QR code to pair your device.
 3. The app runs right on your phone or tablet.
 
 ## [Xamarin Live Player Setup](install.md)

--- a/docs/tools/workbooks/sdk/integrations.md
+++ b/docs/tools/workbooks/sdk/integrations.md
@@ -74,7 +74,7 @@ no public APIs and simply perform "behind the scenes" tasks like yielding
 object [representations](~/tools/workbooks/sdk/representations.md).
 
 > [!NOTE]
-> Note: APIs which must be public but should not be surfaced via IntelliSense
+> APIs which must be public but should not be surfaced via IntelliSense
 can be marked with the usual `[EditorBrowsable (EditorBrowsableState.Never)]`
 attribute.
 

--- a/docs/tools/workbooks/sdk/integrations.md
+++ b/docs/tools/workbooks/sdk/integrations.md
@@ -75,7 +75,7 @@ object [representations](~/tools/workbooks/sdk/representations.md).
 
 > [!NOTE]
 > APIs which must be public but should not be surfaced via IntelliSense
-can be marked with the usual `[EditorBrowsable (EditorBrowsableState.Never)]`
-attribute.
+> can be marked with the usual `[EditorBrowsable (EditorBrowsableState.Never)]`
+> attribute.
 
 [nuget]: https://nuget.org/packages/Xamarin.Workbooks.Integration

--- a/docs/tools/workbooks/sdk/representations.md
+++ b/docs/tools/workbooks/sdk/representations.md
@@ -82,7 +82,7 @@ public sealed class Person : ISerializableObject
 ```
 
 > [!NOTE]
-> Note: APIs that produce `ISerializableObject` objects directly do
+> APIs that produce `ISerializableObject` objects directly do
 not need to be handled by a `RepresentationProvider`. If the object you
 want to display is **not** an `ISerializableObject`, you will want to
 handle wrapping it in your `RepresentationProvider`.

--- a/docs/tools/workbooks/sdk/representations.md
+++ b/docs/tools/workbooks/sdk/representations.md
@@ -83,9 +83,9 @@ public sealed class Person : ISerializableObject
 
 > [!NOTE]
 > APIs that produce `ISerializableObject` objects directly do
-not need to be handled by a `RepresentationProvider`. If the object you
-want to display is **not** an `ISerializableObject`, you will want to
-handle wrapping it in your `RepresentationProvider`.
+> not need to be handled by a `RepresentationProvider`. If the object you
+> want to display is **not** an `ISerializableObject`, you will want to
+> handle wrapping it in your `RepresentationProvider`.
 
 ### Rendering a Representation
 

--- a/docs/tools/workbooks/troubleshooting/android.md
+++ b/docs/tools/workbooks/troubleshooting/android.md
@@ -27,9 +27,9 @@ if you are not familiar with the process.
 
 > [!NOTE]
 > Workbooks 1.1 and earlier will try (and fail!) to use ARM emulators
-if they are available. To work around this, launch the x86 emulator of your
-choice before opening or creating an Android workbook. Workbooks will always
-prefer to connect to a running emulator, as long as it is compatible.
+> if they are available. To work around this, launch the x86 emulator of your
+> choice before opening or creating an Android workbook. Workbooks will always
+> prefer to connect to a running emulator, as long as it is compatible.
 
 ## Workbooks Won't Load
 

--- a/docs/tools/workbooks/troubleshooting/android.md
+++ b/docs/tools/workbooks/troubleshooting/android.md
@@ -25,7 +25,8 @@ not supported. Use `x86` or `x86_64` devices only.
 Please read [our documentation on setting up Android emulators][android-emu]
 if you are not familiar with the process.
 
-**NOTE:** Workbooks 1.1 and earlier will try (and fail!) to use ARM emulators
+> [!NOTE]
+> Workbooks 1.1 and earlier will try (and fail!) to use ARM emulators
 if they are available. To work around this, launch the x86 emulator of your
 choice before opening or creating an Android workbook. Workbooks will always
 prefer to connect to a running emulator, as long as it is compatible.
@@ -37,14 +38,14 @@ prefer to connect to a running emulator, as long as it is compatible.
 First, check that your emulator has fully-working network access by testing any
 website in the emulator's web browser.
 
-### Visual Studio Android Emulator cannot connect to internet
+### Visual Studio Android Emulator cannot connect to the Internet
 
 If your emulator does not have network access, you may need to follow these
 steps to fix your Hyper-V network switch. If you switch between Wi-Fi networks
 frequently you may need to repeat this periodically:
 
 0. **Make sure any critical network operations are complete, as this may
-   temporarily disconnect Windows from the internet.**
+   temporarily disconnect Windows from the Internet.**
 1. Close emulators.
 2. Open `Hyper-V Manager`.
 3. Under `Actions`, open `Virtual Switch Manager...`.
@@ -52,7 +53,7 @@ frequently you may need to repeat this periodically:
 5. Click `OK`.
 6. Launch VS Android Emulator. You will probably be prompted to recreate
    virtual network switch.
-7. Test that VS Android Emulator's browser can access the internet.
+7. Test that VS Android Emulator's browser can access the Internet.
 
 [android-emu]: https://developer.xamarin.com/guides/android/deployment,_testing,_and_metrics/debug-on-emulator/
 

--- a/docs/tools/workbooks/troubleshooting/android.md
+++ b/docs/tools/workbooks/troubleshooting/android.md
@@ -38,14 +38,14 @@ prefer to connect to a running emulator, as long as it is compatible.
 First, check that your emulator has fully-working network access by testing any
 website in the emulator's web browser.
 
-### Visual Studio Android Emulator cannot connect to the Internet
+### Visual Studio Android Emulator cannot connect to the internet
 
 If your emulator does not have network access, you may need to follow these
 steps to fix your Hyper-V network switch. If you switch between Wi-Fi networks
 frequently you may need to repeat this periodically:
 
 0. **Make sure any critical network operations are complete, as this may
-   temporarily disconnect Windows from the Internet.**
+   temporarily disconnect Windows from the internet.**
 1. Close emulators.
 2. Open `Hyper-V Manager`.
 3. Under `Actions`, open `Virtual Switch Manager...`.
@@ -53,7 +53,7 @@ frequently you may need to repeat this periodically:
 5. Click `OK`.
 6. Launch VS Android Emulator. You will probably be prompted to recreate
    virtual network switch.
-7. Test that VS Android Emulator's browser can access the Internet.
+7. Test that VS Android Emulator's browser can access the internet.
 
 [android-emu]: https://developer.xamarin.com/guides/android/deployment,_testing,_and_metrics/debug-on-emulator/
 

--- a/docs/tools/workbooks/workbook.md
+++ b/docs/tools/workbooks/workbook.md
@@ -50,7 +50,7 @@ There are some known limitations with NuGet package support in Workbooks:
     the managed library.
   * Packages which depend on `.targets` files or PowerShell scripts will likely
     fail to work as expected.
-  * To modify a package dependency, edit the workbook's manifest with
+  * To remove or modify a package dependency, edit the workbook's manifest with
     a text editor. Proper package management is on the way.
 
 ### Xamarin.Forms Support

--- a/docs/tools/workbooks/workbook.md
+++ b/docs/tools/workbooks/workbook.md
@@ -30,7 +30,7 @@ inline live-diagnostics, and multi-line statement support.
 [ ![](workbook-images/inspector-0.6.0-repl-small.png "The code editing window provides code completion, syntax coloring, inline live-diagnostics, and multi-line statement support")](workbook-images/inspector-0.6.0-repl.png#lightbox)
 
 Xamarin Workbooks are saved in a `.workbook` file, which is a CommonMark
-file with some metadata at the top (see [Workbooks File Types](#Workbooks_Files_Types) for more
+file with some metadata at the top (see [Workbooks File Types](#workbooks-files-types) for more
 details on how workbooks can be saved).
 
 ### NuGet Package Support
@@ -50,7 +50,7 @@ There are some known limitations with NuGet package support in Workbooks:
     the managed library.
   * Packages which depend on `.targets` files or PowerShell scripts will likely
     fail to work as expected.
-  * To remove or modify a package dependency, edit the workbook's manifest with
+  * To modify a package dependency, edit the workbook's manifest with
     a text editor. Proper package management is on the way.
 
 ### Xamarin.Forms Support
@@ -171,7 +171,7 @@ directory is opened in Workbooks 0.99.3 or later, when it is saved, it will be
 converted into a `.workbook` package. This is true on both Mac and Windows.
 
 > [!NOTE]
-> **NOTE:** Windows users will open the `package.workbook\index.workbook` file
+> Windows users will open the `package.workbook\index.workbook` file
 directly, but otherwise the package will behave the same as on Mac.
 
 ### Archives


### PR DESCRIPTION
- Typos
- Removed duplicate **Note:** texts inside the Note boxes.
- internet -> Internet as is used in other places of Microsoft Docs
- Fixed a broken internal link with capital letters
- Package dependencies can now be removed in the Workbooks window, no edits to the manifest file are required. Modifications (for example, version number) still require manual edits, as far as I can see.