### PR TITLE
Correct method used in transition documentation

### DIFF
--- a/docs/ios/user-interface/ios-ui/view-controllers/transitions.md
+++ b/docs/ios/user-interface/ios-ui/view-controllers/transitions.md
@@ -115,7 +115,7 @@ public class CustomTransitionAnimator : UIViewControllerAnimatedTransitioning
 
 Now, when the button is tapped, the animation implemented in the `UIViewControllerAnimatedTransitioning` class is used:
 
- ![](transitions-images/custom-transition.png "An example of the zoom in effect running") 
+ ![](transitions-images/custom-transition.png "An example of the zoom in effect running")
 
 ## Collection View Transitions
 

--- a/docs/ios/user-interface/ios-ui/view-controllers/transitions.md
+++ b/docs/ios/user-interface/ios-ui/view-controllers/transitions.md
@@ -63,7 +63,7 @@ public class TransitioningDelegate : UIViewControllerTransitioningDelegate
 {
 	CustomTransitionAnimator animator;
 
-	public override IUIViewControllerAnimatedTransitioning PresentingController (UIViewController presented, UIViewController presenting, UIViewController source)
+	public override IUIViewControllerAnimatedTransitioning GetAnimationControllerForPresentedController (UIViewController presented, UIViewController presenting, UIViewController source)
 	{
 		animator = new CustomTransitionAnimator ();
 		return animator;
@@ -71,7 +71,7 @@ public class TransitioningDelegate : UIViewControllerTransitioningDelegate
 }
 ```
 
-When the transition takes place, the system creates an instance of `IUIViewControllerContextTransitioning`, which it passed to the animator’s methods. `IUIViewControllerContextTransitioning` contains the `ContainerView` where the animation occurs, as well as the view controller initiating the transition and the view controller being transitioned to.
+If you would want to also have a custom animation when the view is being dismissed you have to override the `GetAnimationControllerForDismissedController` in the `TransitionDelegate`. When the transition takes place, the system creates an instance of `IUIViewControllerContextTransitioning`, which it passed to the animator’s methods. `IUIViewControllerContextTransitioning` contains the `ContainerView` where the animation occurs, as well as the view controller initiating the transition and the view controller being transitioned to.
 
 The `UIViewControllerAnimatedTransitioning` class handles the actual animation. Two methods must be implemented:
 
@@ -115,7 +115,7 @@ public class CustomTransitionAnimator : UIViewControllerAnimatedTransitioning
 
 Now, when the button is tapped, the animation implemented in the `UIViewControllerAnimatedTransitioning` class is used:
 
- ![](transitions-images/custom-transition.png "An example of the zoom in effect running")
+ ![](transitions-images/custom-transition.png "An example of the zoom in effect running") 
 
 ## Collection View Transitions
 

--- a/docs/ios/user-interface/ios-ui/view-controllers/transitions.md
+++ b/docs/ios/user-interface/ios-ui/view-controllers/transitions.md
@@ -71,7 +71,7 @@ public class TransitioningDelegate : UIViewControllerTransitioningDelegate
 }
 ```
 
-If you would want to also have a custom animation when the view is being dismissed you have to override the `GetAnimationControllerForDismissedController` in the `TransitionDelegate`. When the transition takes place, the system creates an instance of `IUIViewControllerContextTransitioning`, which it passed to the animator’s methods. `IUIViewControllerContextTransitioning` contains the `ContainerView` where the animation occurs, as well as the view controller initiating the transition and the view controller being transitioned to.
+When the transition takes place, the system creates an instance of `IUIViewControllerContextTransitioning`, which it passed to the animator’s methods. `IUIViewControllerContextTransitioning` contains the `ContainerView` where the animation occurs, as well as the view controller initiating the transition and the view controller being transitioned to.
 
 The `UIViewControllerAnimatedTransitioning` class handles the actual animation. Two methods must be implemented:
 


### PR DESCRIPTION
The currently documented method does not exist and is confusing. Corrected it to the method used in the latest implementation of the Xamarin.iOS SDK.