### PR TITLE
Remove links to Jenkins builds

### DIFF
--- a/docs/android/platform/embedding-net-in-java.md
+++ b/docs/android/platform/embedding-net-in-java.md
@@ -30,7 +30,7 @@ following:
     later must be installed.
 
 -   **Xamarin.Android** &ndash;
-    [Xamarin.Android 7.4.99](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/)
+    [Xamarin.Android 7.4.99](https://www.visualstudio.com/xamarin/)
     or later must be installed.
 
 -   **Java Developer Kit** &ndash;

--- a/docs/tools/dotnet-embedding/android/index.md
+++ b/docs/tools/dotnet-embedding/android/index.md
@@ -15,7 +15,7 @@ ms.date: 11/14/2017
 
 For Xamarin.Android to work with .NET Embedding, you need the following:
 
-* Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
+* [Xamarin.Android 7.4.99](https://www.visualstudio.com/xamarin/) or later
 * [Android Studio 3.x](https://developer.android.com/studio/index.html) with Java 1.8
 
 # Callbacks

--- a/docs/tools/dotnet-embedding/get-started/java/android.md
+++ b/docs/tools/dotnet-embedding/get-started/java/android.md
@@ -14,7 +14,7 @@ ms.date: 11/14/2017
 
 In addition to the requirements from our [Getting started with Java](~/tools/dotnet-embedding/get-started/java/index.md) guide you'll also need:
 
-* Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
+* [Xamarin.Android 7.4.99](https://www.visualstudio.com/xamarin/) or later
 * [Android Studio 3.x](https://developer.android.com/studio/index.html) with Java 1.8
 
 As an overview, we will:

--- a/docs/tools/dotnet-embedding/get-started/java/index.md
+++ b/docs/tools/dotnet-embedding/get-started/java/index.md
@@ -29,7 +29,7 @@ For Windows:
 * Windows 10 SDK
 
 For Android:
-* Xamarin.Android 7.4.99 or later (build from [Jenkins](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/))
+* [Xamarin.Android 7.4.99](https://www.visualstudio.com/xamarin/) or later
 * [Android Studio 3.x](https://developer.android.com/studio/index.html) with Java 1.8
 
 You can use [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) to edit and compile your C# code.

--- a/docs/tools/dotnet-embedding/get-started/objective-c/ios.md
+++ b/docs/tools/dotnet-embedding/get-started/objective-c/ios.md
@@ -16,7 +16,7 @@ ms.date: 11/14/2017
 
 In addition to the requirements from our [Getting started with Objective-C](~/tools/dotnet-embedding/get-started/objective-c/index.md) guide you'll also need:
 
-* [Xamarin.iOS 10.11+](https://jenkins.mono-project.com/view/Xamarin.MaciOS/job/xamarin-macios-builds-master/) from our _master_ branch.
+* [Xamarin.iOS 10.11](https://www.visualstudio.com/xamarin/) or later
 
 ## Hello world
 


### PR DESCRIPTION
The stable channel now includes Xamarin.iOS 11.6 and Xamarin.Android 8.1 so linking to random Jenkins builds is no longer required.