### PR TITLE
Fix legacy links to www.mono-project.com

### DIFF
--- a/docs/android/deploy-test/gdb.md
+++ b/docs/android/deploy-test/gdb.md
@@ -193,7 +193,7 @@ app instances. This will not work on pre-Android v4.0 targets.
 ### `mono_pmip` doesn't work
 
 The `mono_pmip` function (useful for
-[obtaining managed stack frames](http://www.mono-project.com/Debugging#Debugging_with_GDB)) 
+[obtaining managed stack frames](http://www.mono-project.com/docs/debug+profile/debug/#debugging-with-gdb)) 
 is exported from `libmonosgen-2.0.so`, which the `_Gdb` target does not
 currently pull down. (This will be fixed in a future release.)
 

--- a/docs/android/internals/garbage-collection.md
+++ b/docs/android/internals/garbage-collection.md
@@ -12,7 +12,7 @@ ms.date: 03/15/2018
 # Garbage Collection
 
 Xamarin.Android uses Mono's 
-[Simple Generational garbage collector](http://www.mono-project.com/Compacting_GC). 
+[Simple Generational garbage collector](http://www.mono-project.com/docs/advanced/garbage-collector/sgen/). 
 This is a mark-and-sweep garbage collector with two generations and a *large 
 object space*, with two kinds of collections: 
 

--- a/docs/android/platform/binding-java-library/index.md
+++ b/docs/android/platform/binding-java-library/index.md
@@ -144,5 +144,5 @@ The following binding scenario guides can help you bind a Java library (or libra
 ## Related Links
 
 - [Working with JNI](~/android/platform/java-integration/working-with-jni.md)
-- [GAPI Metadata](http://www.mono-project.com/GAPI#Metadata)
+- [GAPI Metadata](http://www.mono-project.com/docs/gui/gtksharp/gapi/#metadata)
 - [Using Native Libraries](~/android/platform/native-libraries.md)

--- a/docs/cross-platform/macios/binding/objective-c-libraries.md
+++ b/docs/cross-platform/macios/binding/objective-c-libraries.md
@@ -19,7 +19,7 @@ use to bring the iOS and Mac APIs to C#.
 
 This document describes how to bind Objective-C APIs, if you are
 binding just C APIs, you should use the standard .NET mechanism for
-this, [the P/Invoke framework](http://mono-project.com/Dllimport).
+this, [the P/Invoke framework](http://www.mono-project.com/docs/advanced/pinvoke/).
 Details on how to statically link a C library are available on the
 [Linking Native Libraries](~/ios/platform/native-interop.md)
 page.

--- a/docs/ios/internals/limitations.md
+++ b/docs/ios/internals/limitations.md
@@ -24,7 +24,7 @@ These are the Xamarin.iOS limitations compared to desktop Mono:
 Unlike traditional Mono/.NET, code on the iPhone is statically compiled ahead
 	of time instead of being compiled on demand by a JIT compiler.
 
-Mono's [Full AOT](http://www.mono-project.com/AOT#Full_AOT) technology has a few limitations
+Mono's [Full AOT](http://www.mono-project.com/docs/advanced/aot/#full-aot) technology has a few limitations
 	with respect to generics, these are caused because not every
 	possible generic instantiation can be determined up front at
 	compile time. This is not a problem for regular .NET or Mono

--- a/docs/ios/internals/objective-c-selectors.md
+++ b/docs/ios/internals/objective-c-selectors.md
@@ -15,7 +15,7 @@ message that can be sent to an object or a *class*. [Xamarin.iOS](~/ios/internal
 to instance methods, and class selectors to static methods.
 
 Unlike normal C functions (and like C++ member functions), you cannot
-directly invoke a selector using [P/Invoke](http://www.mono-project.com/Dllimport).
+directly invoke a selector using [P/Invoke](http://www.mono-project.com/docs/advanced/pinvoke/).
 (*Aside*: in theory you could use P/Invoke for non-virtual C++ member
 functions, but you'd need to worry about per-compiler name mangling, which is a
 world of pain better ignored.) Instead, selectors are sent to an Objective-C

--- a/docs/ios/platform/binding-objective-c/walkthrough.md
+++ b/docs/ios/platform/binding-objective-c/walkthrough.md
@@ -185,7 +185,7 @@ Creating a fat binary is a three step process:
 
 While these three steps are rather straightforward, and it may be necessary to repeat them in the future when the Objective-C library receives updates or if we require bug fixes. If you decide to automate these steps, it will simplify the future maintenance and support of the iOS binding project.
 
-There are many tools available to automate such tasks - a shell script, [rake](http://rake.rubyforge.org/), [xbuild](http://www.mono-project.com/Microsoft.Build), and [make](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/make.1.html). When we installed the Xcode Command Line tools, we also installed make, so that is the build system that will be used for this walkthrough. Here is a **Makefile** that you can use to create a multi-architecture shared library that will work on an iOS device and the simulator for the any library:
+There are many tools available to automate such tasks - a shell script, [rake](http://rake.rubyforge.org/), [xbuild](http://www.mono-project.com/docs/tools+libraries/tools/xbuild/), and [make](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/make.1.html). When we installed the Xcode Command Line tools, we also installed make, so that is the build system that will be used for this walkthrough. Here is a **Makefile** that you can use to create a multi-architecture shared library that will work on an iOS device and the simulator for the any library:
 
 ```bash
 XBUILD=/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild

--- a/docs/ios/platform/native-interop.md
+++ b/docs/ios/platform/native-interop.md
@@ -143,7 +143,7 @@ There are two kinds of native libraries available on iOS:
 -  Static libraries that you ship with your application.
 
 
-To access methods defined in either one of those, you use [Mono's P/Invoke functionality](http://www.mono-project.com/Interop_with_Native_Libraries) which is the same technology that you
+To access methods defined in either one of those, you use [Mono's P/Invoke functionality](http://www.mono-project.com/docs/advanced/pinvoke/) which is the same technology that you
 would use in .NET, which is roughly:
 
 -  Determine which C function you want to invoke


### PR DESCRIPTION
The URL structure was changed a few years ago when we moved from MediaWiki.