### PR TITLE
Fixes to the macOS UI article

### DIFF
--- a/docs/mac/user-interface/index.md
+++ b/docs/mac/user-interface/index.md
@@ -18,7 +18,7 @@ When working with C# and .NET in a Xamarin.Mac application, you have access to t
 
 The guides listed below give detailed information about working with macOS UI elements in a Xamarin.Mac application. It is highly suggested that you work through the [Hello, Mac](~/mac/get-started/hello-mac.md) article first, specifically the [Introduction to Xcode and Interface Builder](~/mac/get-started/hello-mac.md#Introduction_to_Xcode_and_Interface_Builder) and [Outlets and Actions](~/mac/get-started/hello-mac.md#Outlets_and_Actions) sections, as it covers key concepts and techniques that we'll be using in every article.
 
-You may want to take a look at the [Exposing C# classes / methods to Objective-C](~/mac/internals/how-it-works.md#exposing-c-classes--methods-to-objective-c) section of the [Xamarin.Mac Internals](~/mac/internals/how-it-works.md) document as well, it explains the `Register` and `Export` attributes used to wire-up your C# classes to Objective-C objects and UI elements.
+You may want to take a look at the [Exposing C# classes / methods to Objective-C](~/mac/internals/how-it-works.md#exposing-c-classes--methods-to-objective-c) section of the [Xamarin.Mac Internals](~/mac/internals/how-it-works.md) document as well, as it explains the `Register` and `Export` attributes used to wire-up your C# classes to Objective-C objects and UI elements.
 
 ## [Windows](~/mac/user-interface/window.md)
 

--- a/docs/mac/user-interface/index.md
+++ b/docs/mac/user-interface/index.md
@@ -18,55 +18,55 @@ When working with C# and .NET in a Xamarin.Mac application, you have access to t
 
 The guides listed below give detailed information about working with macOS UI elements in a Xamarin.Mac application. It is highly suggested that you work through the [Hello, Mac](~/mac/get-started/hello-mac.md) article first, specifically the [Introduction to Xcode and Interface Builder](~/mac/get-started/hello-mac.md#Introduction_to_Xcode_and_Interface_Builder) and [Outlets and Actions](~/mac/get-started/hello-mac.md#Outlets_and_Actions) sections, as it covers key concepts and techniques that we'll be using in every article.
 
-You may want to take a look at the [Exposing C# classes / methods to Objective-C](~/mac/internals/how-it-works.md#exposing-c-classes--methods-to-objective-c) section of the [Xamarin.Mac Internals](~/mac/internals/how-it-works.md) document as well, it explains the `Register` and `Export` commands used to wire-up your C# classes to Objective-C objects and UI elements.
+You may want to take a look at the [Exposing C# classes / methods to Objective-C](~/mac/internals/how-it-works.md#exposing-c-classes--methods-to-objective-c) section of the [Xamarin.Mac Internals](~/mac/internals/how-it-works.md) document as well, it explains the `Register` and `Export` attributes used to wire-up your C# classes to Objective-C objects and UI elements.
 
 ## [Windows](~/mac/user-interface/window.md)
 
-This article covers working with Windows and Panels in a Xamarin.Mac application. It covers creating and maintaining Windows and Panels in Xcode and Interface Builder, loading Windows and Panels from `.storyboard` or `.xib` files, using Windows and responding to Windows in C# code.
+This article covers working with windows and panels in a Xamarin.Mac application. It covers creating and maintaining windows and panels in Xcode and Interface Builder, loading windows and panels from `.storyboard` or `.xib` files, using windows and responding to windows in C# code.
 
 ## [Dialogs](~/mac/user-interface/dialog.md)
 
-This article covers working with Dialogs and Modal Windows in a Xamarin.Mac application. It covers creating and maintaining Modal Windows in Xcode and Interface builder, working with standard dialogs, displaying and responding to Windows in C# code.
+This article covers working with dialogs and modal windows in a Xamarin.Mac application. It covers creating and maintaining modal windows in Xcode and Interface Builder, working with standard dialogs, and displaying and responding to windows in C# code.
 
 ## [Alerts](~/mac/user-interface/alert.md)
 
-This article covers working with Alerts in a Xamarin.Mac application. It covers creating and displaying Alerts from C# code and responding to Alerts.
+This article covers working with alerts in a Xamarin.Mac application. It covers creating and displaying alerts from C# code and responding to alerts.
 
 ## [Menus](~/mac/user-interface/menu.md)
 
-Menus are used in various parts of a Mac application's user interface; from the application's main menu at the top of the screen to pop-up and contextual menus that can appear anywhere in a window. Menus are an integral part of a Mac application's user experience. This article covers working with Cocoa Menus in a Xamarin.Mac application.
+Menus are used in various parts of a Mac application's user interface; from the application's main menu at the top of the screen to pop-up menus and contextual menus that can appear anywhere in a window. Menus are an integral part of a Mac application's user experience. This article covers working with Cocoa menus in a Xamarin.Mac application.
 
 ## [Standard Controls](~/mac/user-interface/standard-controls.md)
 
-Working with the standard AppKit controls such as Buttons, Labels, Text Fields, Check Boxes and Segmented Controls in a Xamarin.Mac application. This guide covers adding them to a user interface design in Xcode's Interface Builder, exposing them to code through Outlets and Actions and working with AppKit controls in C# code.
+Working with the standard AppKit controls such as buttons, labels, text fields, check boxes, and segmented controls in a Xamarin.Mac application. This guide covers adding them to a user interface design in Xcode's Interface Builder, exposing them to code through outlets and actions, and working with AppKit controls in C# code.
 
 ## [Toolbars](~/mac/user-interface/toolbar.md)
 
-This article covers working with Toolbars in a Xamarin.Mac application. It covers creating and maintaining Toolbars in Xcode and Interface Builder, how to expose the Toolbar items to code using Outlets and Actions, enabling and disabling Toolbar items and finally responding to Toolbar items in C# code.
+This article covers working with toolbars in a Xamarin.Mac application. It covers creating and maintaining toolbars in Xcode and Interface Builder, how to expose the toolbar items to code using outlets and actions, enabling and disabling toolbar items, and finally responding to Toolbar items in C# code.
 
 ## [Table Views](~/mac/user-interface/table-view.md)
 
-This article covers working with Table Views in a Xamarin.Mac application. It covers creating and maintaining Table Views in Xcode and Interface Builder, how to expose the Table View items to code using Outlets and Actions, populating Table Views and finally responding to Table View items in C# code.
+This article covers working with table Vvews in a Xamarin.Mac application. It covers creating and maintaining table views in Xcode and Interface Builder, how to expose the table view items to code using outlets and actions, populating table views, and responding to table view items in C# code.
 
 ## [Outline Views](~/mac/user-interface/outline-view.md)
 
-This article covers working with Outline Views in a Xamarin.Mac application. It covers creating and maintaining Outline Views in Xcode and Interface Builder, how to expose the Outline View items to code using Outlets and Actions, populating Outline Views and finally responding to Outline View items in C# code.
+This article covers working with outline views in a Xamarin.Mac application. It covers creating and maintaining outline views in Xcode and Interface Builder, how to expose the outline view items to code using outlets and actions, populating outline views, and responding to outline view items in C# code.
 
 ## [Source Lists](~/mac/user-interface/source-list.md)
 
-This article covers working with Source Lists in a Xamarin.Mac application. It covers creating and maintaining Source Lists in Xcode and Interface Builder, how to expose the Source Lists items to code using Outlets and Actions, populating Source Lists and finally responding to Source List items in C# code.
+This article covers working with source lists in a Xamarin.Mac application. It covers creating and maintaining source lists in Xcode and Interface Builder, how to expose source list items to code using outlets and actions, populating source lists, and responding to source list items in C# code.
 
 ## [Collection Views](~/mac/user-interface/collection-view.md)
 
-This article covers working with Collection Views in a Xamarin.Mac application. It covers creating and maintaining Collection Views in Xcode and Interface Builder, how to expose the Collection View items to code using Outlets and Actions, populating Collection Views and finally responding to Collection Views in C# code.
+This article covers working with collection views in a Xamarin.Mac application. It covers creating and maintaining collection views in Xcode and Interface Builder, how to expose the collection view items to code using outlets and actions, populating collection views, and responding to collection views in C# code.
 
 ## [Creating Custom User Controls](~/mac/user-interface/custom-controls.md)
 
-This article covers creating custom user interface controls (by inheriting from `NSControl`), drawing a custom interface for the control and creating custom actions that can be used with Xcode's Interface Builder.
+This article covers creating custom user interface controls (by inheriting from `NSControl`), drawing a custom interface for the control, and creating custom actions that can be used with Xcode's Interface Builder.
 
 ## Mac Samples Gallery
 
-We also suggest taking a look at the [Mac Samples Gallery](https://developer.xamarin.com/samples/mac/all/), it includes a wealth of ready-to-use code that can help you get a Xamarin.Mac project off the ground quickly.
+We also suggest taking a look at the [Mac Samples Gallery](https://developer.xamarin.com/samples/mac/all/). It includes a wealth of ready-to-use code that can help you get a Xamarin.Mac project off the ground quickly.
 
 ## Related Links
 

--- a/docs/mac/user-interface/index.md
+++ b/docs/mac/user-interface/index.md
@@ -14,15 +14,15 @@ ms.date: 10/19/2016
 
 _This article links to guides that describe various macOS UI controls._
 
-When working with C# and .NET in a Xamarin.Mac application, you have access to the same User Interface controls that a developer working in in *Objective-C* and *Xcode* does. Because Xamarin.Mac integrates directly with Xcode, you can use Xcode's _Interface Builder_ to create and maintain your User Interfaces (or optionally create them directly in C# code). 
+When working with C# and .NET in a Xamarin.Mac application, you have access to the same user interface controls that a developer working in *Objective-C* and *Xcode* does. Because Xamarin.Mac integrates directly with Xcode, you can use Xcode's _Interface Builder_ to create and maintain your user interfaces (or optionally create them directly in C# code).
 
 The guides listed below give detailed information about working with macOS UI elements in a Xamarin.Mac application. It is highly suggested that you work through the [Hello, Mac](~/mac/get-started/hello-mac.md) article first, specifically the [Introduction to Xcode and Interface Builder](~/mac/get-started/hello-mac.md#Introduction_to_Xcode_and_Interface_Builder) and [Outlets and Actions](~/mac/get-started/hello-mac.md#Outlets_and_Actions) sections, as it covers key concepts and techniques that we'll be using in every article.
 
-You may want to take a look at the [Exposing C# classes / methods to Objective-C](~/mac/internals/how-it-works.md) section of the [Xamarin.Mac Internals](~/mac/internals/how-it-works.md) document as well, it explains the `Register` and `Export` commands used to wire-up your C# classes to Objective-C objects and UI Elements.
+You may want to take a look at the [Exposing C# classes / methods to Objective-C](~/mac/internals/how-it-works.md#exposing-c-classes--methods-to-objective-c) section of the [Xamarin.Mac Internals](~/mac/internals/how-it-works.md) document as well, it explains the `Register` and `Export` commands used to wire-up your C# classes to Objective-C objects and UI elements.
 
 ## [Windows](~/mac/user-interface/window.md)
 
-This article covers working with Windows and Panels in a Xamarin.Mac application. It covers creating and maintaining Windows and Panels in Xcode and Interface builder, loading Windows and Panels from `.storyboard` or `.xib` files, using Windows and responding to Windows in C# code.
+This article covers working with Windows and Panels in a Xamarin.Mac application. It covers creating and maintaining Windows and Panels in Xcode and Interface Builder, loading Windows and Panels from `.storyboard` or `.xib` files, using Windows and responding to Windows in C# code.
 
 ## [Dialogs](~/mac/user-interface/dialog.md)
 
@@ -34,41 +34,40 @@ This article covers working with Alerts in a Xamarin.Mac application. It covers 
 
 ## [Menus](~/mac/user-interface/menu.md)
 
-Menus are used in various parts of a Mac application's user interface; from the application's main menu at the top of the screen to pop-up and contextual menus that can appear anywhere in a window. Menus are a integral part of a Mac application's user experience. This article covers working with Cocoa Menus in a Xamarin.Mac application.
+Menus are used in various parts of a Mac application's user interface; from the application's main menu at the top of the screen to pop-up and contextual menus that can appear anywhere in a window. Menus are an integral part of a Mac application's user experience. This article covers working with Cocoa Menus in a Xamarin.Mac application.
 
 ## [Standard Controls](~/mac/user-interface/standard-controls.md)
 
-Working with the standard AppKit controls such as Buttons, Labels, Text Fields, Check Boxes and Segmented Controls in a Xamarin.Mac application. This guide covers adding them to a User Interface Design in Xcode's Interface Builder, exposing them to code through Outlets and Actions and working with AppKit Controls in C# Code.
+Working with the standard AppKit controls such as Buttons, Labels, Text Fields, Check Boxes and Segmented Controls in a Xamarin.Mac application. This guide covers adding them to a user interface design in Xcode's Interface Builder, exposing them to code through Outlets and Actions and working with AppKit controls in C# code.
 
- 
 ## [Toolbars](~/mac/user-interface/toolbar.md)
 
-This article covers working with Toolbars in a Xamarin.Mac application. It covers creating and maintaining Toolbars in Xcode and Interface builder, how to expose the Toolbar Items to code using Outlets and Actions, enabling and disabling Toolbar Items and finally responding to Toolbar Items in C# code.
+This article covers working with Toolbars in a Xamarin.Mac application. It covers creating and maintaining Toolbars in Xcode and Interface Builder, how to expose the Toolbar items to code using Outlets and Actions, enabling and disabling Toolbar items and finally responding to Toolbar items in C# code.
 
 ## [Table Views](~/mac/user-interface/table-view.md)
 
-This article covers working with Table Views in a Xamarin.Mac application. It covers creating and maintaining Table Views in Xcode and Interface builder, how to expose the Table View Items to code using Outlets and Actions, populating Table Views and finally responding to Table View Items in C# code.
+This article covers working with Table Views in a Xamarin.Mac application. It covers creating and maintaining Table Views in Xcode and Interface Builder, how to expose the Table View items to code using Outlets and Actions, populating Table Views and finally responding to Table View items in C# code.
 
 ## [Outline Views](~/mac/user-interface/outline-view.md)
 
-This article covers working with Outline Views in a Xamarin.Mac application. It covers creating and maintaining Outline Views in Xcode and Interface builder, how to expose the Outline View Items to code using Outlets and Actions, populating Outline Items and finally responding to Outline View Items in C# code.
+This article covers working with Outline Views in a Xamarin.Mac application. It covers creating and maintaining Outline Views in Xcode and Interface Builder, how to expose the Outline View items to code using Outlets and Actions, populating Outline Views and finally responding to Outline View items in C# code.
 
 ## [Source Lists](~/mac/user-interface/source-list.md)
 
-This article covers working with Source Lists in a Xamarin.Mac application. It covers creating and maintaining Source Lists in Xcode and Interface builder, how to expose the Source Lists Items to code using Outlets and Actions, populating Source List Items and finally responding to Source List Items in C# code.
+This article covers working with Source Lists in a Xamarin.Mac application. It covers creating and maintaining Source Lists in Xcode and Interface Builder, how to expose the Source Lists items to code using Outlets and Actions, populating Source Lists and finally responding to Source List items in C# code.
 
 ## [Collection Views](~/mac/user-interface/collection-view.md)
 
-This article covers working with Collection Views in a Xamarin.Mac application. It covers creating and maintaining Collection Views in Xcode and Interface builder, how to expose the Collection View elements to code using Outlets and Actions, populating Collection Views and finally responding to Collection Views in C# code.
+This article covers working with Collection Views in a Xamarin.Mac application. It covers creating and maintaining Collection Views in Xcode and Interface Builder, how to expose the Collection View items to code using Outlets and Actions, populating Collection Views and finally responding to Collection Views in C# code.
 
 ## [Creating Custom User Controls](~/mac/user-interface/custom-controls.md)
 
-This article covers creating custom User Interface controls (by inheriting from `NSControl`), drawing a custom interface for the control and creating custom actions that can be used with Xcode's Interface builder.
+This article covers creating custom user interface controls (by inheriting from `NSControl`), drawing a custom interface for the control and creating custom actions that can be used with Xcode's Interface Builder.
 
 ## Mac Samples Gallery
 
-We also suggest taking a look at the [Mac Samples Gallery](http://developer.xamarin.com/samples/mac/all/), it includes a wealth of ready-to-use code that can help you get a Xamarin.Mac project off the ground quickly.
+We also suggest taking a look at the [Mac Samples Gallery](https://developer.xamarin.com/samples/mac/all/), it includes a wealth of ready-to-use code that can help you get a Xamarin.Mac project off the ground quickly.
 
 ## Related Links
 
-- [macOS Human Interface Guidelines](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/)
+- [macOS Human Interface Guidelines](https://developer.apple.com/macos/human-interface-guidelines/overview/themes/)


### PR DESCRIPTION
- Added the missing section link to the Introduction to Xcode and Interface Builder link
- User Interface -> user interface
- Interface builder -> Interface Builder (product)
- Other capitalization fixes
- http -> https
- Updated the macOS Human Interface Guidelines link on the bottom. The old one still redirects correctly but who knows how long.
