### PR TITLE
Changed 'translationHistory' to 'translateButton'

### DIFF
--- a/docs/android/get-started/hello-android-multiscreen/hello-android-multiscreen-quickstart.md
+++ b/docs/android/get-started/hello-android-multiscreen/hello-android-multiscreen-quickstart.md
@@ -156,7 +156,7 @@ public class MainActivity : Activity
 ```
 
 In the `MainActivity` class, add the following code to register the 
-**Translation History** button (place this line after the `translationHistory` declaration):
+**Translation History** button (place this line after the `translateButton` declaration):
 
 ```csharp
 Button translationHistoryButton = FindViewById<Button> (Resource.Id.TranslationHistoryButton);


### PR DESCRIPTION
There was a typo in the tutorial. It should say to place 'translationHistoryButton' declaration after 'translateButton', not after 'translationHistory' (which is not declared at all here).