### PR TITLE
Update connect-android-emulator-mac-windows.md

### DIFF
--- a/docs/android/troubleshooting/questions/connect-android-emulator-mac-windows.md
+++ b/docs/android/troubleshooting/questions/connect-android-emulator-mac-windows.md
@@ -45,7 +45,7 @@ virtual machine, use the following steps:
     ```bash
     cd /tmp
     mkfifo backpipe
-    nc -kl 5555 0 < backpipe | nc 127.0.0.1 5555 > backpipe
+    nc -kl 5555 0<backpipe | nc 127.0.0.1 5555 > backpipe
     ```
 
     As long as the `nc` commands stay running in a Terminal window, the


### PR DESCRIPTION
There is a very subtle issue on line48: 
> nc -kl 5555 0 < backpipe | nc 127.0.0.1 5555 > backpipe  

There needs to be no spaces between "0 < backpipe" so it reads "0<backpipe" otherwise you will get a message "nc: Can't assign requested address" in the terminal.