### PR TITLE
Updated InstanceId namespace to Android.Gms.Iid

### DIFF
--- a/docs/android/data-cloud/google-messaging/remote-notifications-with-gcm.md
+++ b/docs/android/data-cloud/google-messaging/remote-notifications-with-gcm.md
@@ -328,7 +328,7 @@ using Android.App;
 using Android.Content;
 using Android.Util;
 using Android.Gms.Gcm;
-using Android.Gms.Gcm.Iid;
+using Android.Gms.Iid;
 
 namespace ClientApp
 {

--- a/docs/android/data-cloud/google-messaging/remote-notifications-with-gcm.md
+++ b/docs/android/data-cloud/google-messaging/remote-notifications-with-gcm.md
@@ -529,7 +529,7 @@ replace the template code with the following:
 ```csharp
 using Android.App;
 using Android.Content;
-using Android.Gms.Gcm.Iid;
+using Android.Gms.Iid;
 
 namespace ClientApp
 {


### PR DESCRIPTION
`Android.Gms.Gcm.Iid` namespace is unavailable, but `Android.Gms.Iid` is.

My environment:
```
=== Visual Studio Community 2017 for Mac ===

Version 7.4.2 (build 12)
Installation UUID: 28f1eea7-b9a9-41aa-9950-86c671139291
Runtime:
	Mono 5.8.1.0 (2017-10/6bf3922f3fd) (64-bit)
	GTK+ 2.24.23 (Raleigh theme)

	Package version: 508010000

=== NuGet ===

Version: 4.3.1.4445

=== .NET Core ===

Runtime: /usr/local/share/dotnet/dotnet
Runtime Versions:
	2.0.5
	2.0.3
	2.0.0
SDK: /usr/local/share/dotnet/sdk/2.1.4/Sdks
SDK Versions:
	2.1.4
	2.0.3
	2.0.0
MSBuild SDKs: /Library/Frameworks/Mono.framework/Versions/5.8.1/lib/mono/msbuild/15.0/bin/Sdks

=== Xamarin.Profiler ===

Version: 1.6.1
Location: /Applications/Xamarin Profiler.app/Contents/MacOS/Xamarin Profiler

=== Apple Developer Tools ===

Xcode 9.3 (14154)
Build 9E145

=== Xamarin.Mac ===

Version: 4.2.1.28 (Visual Studio Community)

=== Xamarin.iOS ===

Version: 11.9.1.24 (Visual Studio Community)
Hash: f62de472
Branch: xcode9.3
Build date: 2018-03-29 19:30:53-0400

=== Xamarin.Android ===

Version: 8.2.0.16 (Visual Studio Community)
Android SDK: /Users/joesauve/Library/Developer/Xamarin/android-sdk-macosx
	Supported Android versions:
		4.4 (API level 19)
		5.1 (API level 22)
		6.0 (API level 23)
		7.0 (API level 24)
		7.1 (API level 25)
		8.0 (API level 26)
		8.1 (API level 27)

SDK Tools Version: 26.1.1
SDK Platform Tools Version: 27.0.1
SDK Build Tools Version: 26.0.3

Java SDK: /usr
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)

Android Designer EPL code available here:
https://github.com/xamarin/AndroidDesigner.EPL

=== Xamarin Inspector ===

Version: 1.4.0
Hash: b3f92f9
Branch: master
Build date: Fri, 19 Jan 2018 22:00:34 GMT
Client compatibility: 1

=== Build Information ===

Release ID: 704020012
Git revision: 0d8e3f0a4d683771f17959739956fa09c7ba21e3
Build date: 2018-03-30 10:45:17-04
Xamarin addins: 958839ea56ab1e331caf7c92b6ad50fb9e6ee9d2
Build lane: monodevelop-lion-d15-6

=== Operating System ===

Mac OS X 10.13.4
Darwin 17.5.0 Darwin Kernel Version 17.5.0
    Mon Mar  5 22:24:32 PST 2018
    root:xnu-4570.51.1~1/RELEASE_X86_64 x86_64

=== Enabled user installed addins ===

MvvmCross Template pack 2.0.1
Internet of Things (IoT) development (Preview) 7.1
```