### PR TITLE
Add a step on get started instructions for WHPX

### DIFF
--- a/docs/android/get-started/installation/android-emulator/hardware-acceleration.md
+++ b/docs/android/get-started/installation/android-emulator/hardware-acceleration.md
@@ -47,6 +47,8 @@ To get started with using Hyper-V and the Google Android Emulator:
 
     [![Android SDKs and Tools dialog](hardware-acceleration-images/win/14-sdk-manager.w158-sml.png)](hardware-acceleration-images/win/14-sdk-manager.w158.png#lightbox)
 
+1. **Create a file named** `advancedFeatures.ini` **in the folder** `~\.android\` (aka C:\Users<your-username\.android\) if it doesn't already exist, and add `WindowsHypervisorPlatform = on` to the content of the file.
+
 ### Known Issues
 
 * Performance may be reduced when using certain Intel and AMD-based processors.


### PR DESCRIPTION
When following these instructions, I couldn't succeed, until I've found the workaround of adding “WindowsHypervisorPlatform = on” to ~/.android/advancedFeatures.ini in a comment of this [blog post](https://blogs.msdn.microsoft.com/visualstudio/2018/05/08/hyper-v-android-emulator-support).
So I do think that is essential to add it to the setup instruction steps.