### PR TITLE
Surround LiveReload.Init in DEBUG directive

### DIFF
--- a/docs/xamarin-forms/xaml/live-reload.md
+++ b/docs/xamarin-forms/xaml/live-reload.md
@@ -59,8 +59,10 @@ public partial class App : Application
 	public App ()
 	{
 		// Initialize Live Reload.
+		#if DEBUG
 		LiveReload.Init();
-	
+		#endif
+		
 		InitializeComponent();
 		MainPage = new MainPage();
 	}


### PR DESCRIPTION
Without `#if DEBUG`, LiveReload would be turned on in release mode.