### PR TITLE
Add 1.2+ support for Android HttpClientHandler

### DIFF
--- a/docs/android/app-fundamentals/http-stack.md
+++ b/docs/android/app-fundamentals/http-stack.md
@@ -94,9 +94,9 @@ Beginning with Xamarin.Android 8.3, `HttpClientHandler` defaults to
 Boring SSL (`btls`) as the underlying TLS provider. The Boring SSL
 TLS provider offers the following advantages:
 
--   It supports TLS 1.2.
+-   It supports TLS 1.2+.
 -   It supports all Android versions.
--   It provides TLS 1.2 support for both `HttpClient` and `WebClient`.
+-   It provides TLS 1.2+ support for both `HttpClient` and `WebClient`.
 
 The disadvantage of using Boring SSL as the underling TLS provider is
 that it can increase the size of the resulting APK (it adds about 1MB


### PR DESCRIPTION
I'm changing this taking in mind the previous paragraph:

> HttpClientHandler is a good choice if you need TLS 1.2+ support but must support versions of Android earlier than Android 5.0. It is also a good choice if you need TLS 1.2+ support for WebClient.

So, when using `HttpClientHandler ` with Xamarin.Android 8.3 and above we will have support for TLS 1.2+.