### PR TITLE
Addressed some errors in the Xamarin.Forms QuickStart

### DIFF
--- a/docs/xamarin-forms/get-started/hello-xamarin-forms/quickstart.md
+++ b/docs/xamarin-forms/get-started/hello-xamarin-forms/quickstart.md
@@ -350,7 +350,7 @@ Create the Phoneword application as follows:
 
     namespace Phoneword.Droid
     {
-        [Activity(Label = "Phoneword", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+        [Activity(Label = "Phoneword", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
         public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
         {
             internal static MainActivity Instance { get; private set; }
@@ -479,6 +479,7 @@ Create the Phoneword application as follows:
 37. If you have an iOS device and meet the Mac system requirements for Xamarin.Forms development, use a similar technique to deploy the app to the iOS device. Alternatively, deploy the app to the [iOS remote simulator](~/tools/ios-simulator.md).
 
     Note: phone calls are not supported on all the simulators.
+38. If you get compiler errors in any of the platform-specific projects (e.g., `CS0246 "The type or namespace name 'IDialer' could not be found..."`, you may just need to delete and re-add those projects' references to the **Phoneword** project.
 
 # [Visual Studio for Mac](#tab/vsmac)
 


### PR DESCRIPTION
I had two issues while following the Xamarin.Forms QuickStart documentation, which these tweaks help resolve:

1. I was getting the error message described in #388.  The GitHub comments at the bottom of the page showed that @davidbritch had already "fixed this in a forthcoming update", but that was 6 days ago and the incorrect line of code was still present in the docs.  So this may already be fixed in #388 but I figured I'd throw it in just to be safe.
2. I was getting CS0246 compiler errors in the Android and iOS projects.  For example: "`The type or namespace name 'App' could not be found (are you missing a using directive or an assembly reference?`".  Curiously, that error went away for the Android project when I fixed the first issue above, but the iOS project still gave the same error, maybe just because I didn't have any connected Mac Server.  Either way, [this post](https://blogs.msmvps.com/vstsblog/2016/04/04/solution-for-error-cs0246-the-type-or-namespace-name-app-could-not-be-found-when-building-xamarin-ios/) by MVP Neno Loje offered a solution, so I added a note about it.