### PR TITLE
Update shared project type to .NET Standard

### DIFF
--- a/docs/xamarin-forms/data-cloud/authentication/oauth.md
+++ b/docs/xamarin-forms/data-cloud/authentication/oauth.md
@@ -116,7 +116,7 @@ The following code example shows how to initialize a login presenter in the `Mai
 global::Xamarin.Auth.Presenters.XamarinAndroid.AuthenticationConfiguration.Init(this, bundle);
 ```
 
-The .NET Standard project can then invoke the login presenter as follows:
+The .NET Standard library project can then invoke the login presenter as follows:
 
 ```csharp
 var presenter = new Xamarin.Auth.Presenters.OAuthLoginPresenter();

--- a/docs/xamarin-forms/data-cloud/authentication/oauth.md
+++ b/docs/xamarin-forms/data-cloud/authentication/oauth.md
@@ -116,7 +116,7 @@ The following code example shows how to initialize a login presenter in the `Mai
 global::Xamarin.Auth.Presenters.XamarinAndroid.AuthenticationConfiguration.Init(this, bundle);
 ```
 
-The Portable Class Library (PCL) project can then invoke the login presenter as follows:
+The .NET Standard project can then invoke the login presenter as follows:
 
 ```csharp
 var presenter = new Xamarin.Auth.Presenters.OAuthLoginPresenter();


### PR DESCRIPTION
As of VS 2017, PCL (Portable Class Library) projects are not recommended anymore as the type of shared project for a Xamarin.Forms solution. Users are prompted to migrate to .NET Standard.