### PR TITLE
Update MonoGame link

### DIFF
--- a/docs/cross-platform/app-fundamentals/building-cross-platform-applications/platform-divergence-abstraction-divergent-implementation.md
+++ b/docs/cross-platform/app-fundamentals/building-cross-platform-applications/platform-divergence-abstraction-divergent-implementation.md
@@ -186,7 +186,7 @@ cross-platform functionality:
 
 -   **MvvmCross** -  [https://github.com/slodge/MvvmCross/](https://github.com/slodge/MvvmCross/)
 -   **Vernacular** (for localization) -  [https://github.com/rdio/vernacular/](https://github.com/rdio/vernacular/)
--   **MonoGame** (for XNA games) -  [http://monogame.codeplex.com/](http://monogame.codeplex.com/)
+-   **MonoGame** (for XNA games) -  [http://www.monogame.net](http://www.monogame.net)
 -   **NGraphics** - [NGraphics](https://github.com/praeclarum/NGraphics) and its precursor [https://github.com/praeclarum/CrossGraphics](https://github.com/praeclarum/CrossGraphics)
 
 


### PR DESCRIPTION
Their website is now http://www.monogame.net. The old page does link there, but it's better to provide the correct link to begin with.