### PR TITLE
Fix ModelNotImplementedException

### DIFF
--- a/docs/ios/platform/user-notifications/deprecated/local-notifications-in-ios-walkthrough.md
+++ b/docs/ios/platform/user-notifications/deprecated/local-notifications-in-ios-walkthrough.md
@@ -78,7 +78,7 @@ Let create a simple application that will show local notifications in action. Th
 	            UIAlertController okayAlertController = UIAlertController.Create(notification.AlertAction, notification.AlertBody, UIAlertControllerStyle.Alert);
 	            okayAlertController.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
 
-	            Window.RootViewController.PresentViewController(okayAlertController, true, null);
+	            UIApplication.SharedApplication.KeyWindow.RootViewController.PresentViewController(okayAlertController, true, null);
 
 	            // reset our badge
 	            UIApplication.SharedApplication.ApplicationIconBadgeNumber = 0;


### PR DESCRIPTION
Current implemetation produced Foundation.ModelNotImplementedException for Local Notification in Xamarin Forms

Replaced with with UIApplication.SharedApplication.KeyWindow as described here (https://stackoverflow.com/questions/42716781/foundation-modelnotimplementedexception-for-local-notification-in-xamarin-forms) - this resolved the problem.