### PR TITLE
Rename to Xamarin OpenJDK Distribution

### DIFF
--- a/docs/android/get-started/installation/openjdk.md
+++ b/docs/android/get-started/installation/openjdk.md
@@ -1,6 +1,6 @@
 ---
-title: "Microsoft's OpenJDK Distribution Preview"
-description: "A step-by-step guide to configuring Microsoft's distribution of OpenJDK."
+title: "Xamarin's OpenJDK Distribution Preview"
+description: "A step-by-step guide to configuring Xamarin's distribution of OpenJDK."
 ms.prod: xamarin
 ms.assetid: B5F8503D-F4D1-44CB-8B29-187D1E20C979
 ms.technology: xamarin-android
@@ -9,9 +9,9 @@ ms.author: vyedin
 ms.date: 07/22/2018
 ---
 
-# Microsoft's OpenJDK Distribution Preview
+# Xamarin's OpenJDK Distribution Preview
 
-_This guide describes the steps for switching to the preview release of Microsoft's distribution of the OpenJDK._
+_This guide describes the steps for switching to the preview release of Xamarin's distribution of the OpenJDK._
 
 ![Preview Feature](~/media/shared/preview.png)
 
@@ -31,15 +31,15 @@ The benefits of this move are:
 
 - No more issues with 3rd party servers and installers.
 
-If you’d like to move to the improved experience sooner, builds of the Microsoft OpenJDK distribution are available for you to test on both Windows and Mac. The setup process is described below, and you can revert back to the Oracle JDK at any time.
+If you’d like to move to the improved experience sooner, builds of the Xamarin OpenJDK distribution are available for you to test on both Windows and Mac. The setup process is described below, and you can revert back to the Oracle JDK at any time.
 
 ## Download
 
 To get started, download the correct build for your system:
 
-- **Mac** &ndash; https://dl.xamarin.com/OpenJDK/mac/microsoft-dist-openjdk-1.8.0.9.zip
-- **Windows x86** &ndash; https://dl.xamarin.com/OpenJDK/win32/microsoft-dist-openjdk-1.8.0.9.zip
-- **Windows x64** &ndash; https://dl.xamarin.com/OpenJDK/win64/microsoft-dist-openjdk-1.8.0.9.zip
+- **Mac** &ndash; https://dl.xamarin.com/OpenJDK/mac/xamarin-dist-openjdk-1.8.0.9.zip
+- **Windows x86** &ndash; https://dl.xamarin.com/OpenJDK/win32/xamarin-dist-openjdk-1.8.0.9.zip
+- **Windows x64** &ndash; https://dl.xamarin.com/OpenJDK/win64/xamarin-dist-openjdk-1.8.0.9.zip
 
 ## Configure
 
@@ -55,17 +55,17 @@ Point the IDE to the new JDK:
 
 - **Mac** &ndash; Click **Tools > SDK Manager > Locations** and change the **Java SDK (JDK) Location** to the full path of the OpenJDK installation. In the following example, this path is set to  **$HOME/Library/Developer/Xamarin/jdk/microsoft_dist_openjdk_1.8.0.9**.
 
-![Setting the JDK path for the Microsoft OpenJDK distribution on the Mac](openjdk-images/vsm.png)
+![Setting the JDK path for the Xamarin OpenJDK distribution on the Mac](openjdk-images/vsm.png)
 
 - **Windows** &ndash; Click **Tools > Options > Xamarin > Android Settings** and change the **Java Development Kit Location** to the full path of the OpenJDK installation. In the following example, this path is set to **C:\\Program Files\\Android\\jdk\\microsoft_dist_openjdk_1.8.0.9**:
 
-![Setting the JDK path for the Microsoft OpenJDK distribution on Windows](openjdk-images/vs.png)
+![Setting the JDK path for the Xamarin OpenJDK distribution on Windows](openjdk-images/vs.png)
 
 ## Revert
 
 To revert to the Oracle JDK, change the Java SDK location to the previously-used Oracle JDK path and rebuild the solution. On Mac, you can revert to the Oracle JDK path by clicking **Reset to Defaults**.
 
-If you have any problems with the Microsoft OpenJDK distribution, please report issues by using the feedback tool in your IDE so that they can be tracked and corrected quickly.
+If you have any problems with the Xamarin OpenJDK distribution, please report issues by using the feedback tool in your IDE so that they can be tracked and corrected quickly.
 
 ## Known Issues & Planned Fix Dates
 
@@ -73,4 +73,4 @@ The `JAVA_HOME` environment variable may not be correctly exported to the SDK an
 
 ## Summary
 
-In this article, you learned how to configure your IDE to use the preview release of Microsoft's OpenJDK distribution, which is slated for stable release later in 2018.
+In this article, you learned how to configure your IDE to use the preview release of Xamarin's OpenJDK distribution, which is slated for stable release later in 2018.


### PR DESCRIPTION
Given this distribution is specifically designed for Xamarin/Android apps and not a general purpose OpenJDK for any kind of Java application (e.g. server-side Java apps on Azure; desktop Java apps on Windows), it is important to name this as *Xamarin OpenJDK Distribution*.