### PR TITLE
Fix typo in method name

### DIFF
--- a/docs/essentials/accelerometer.md
+++ b/docs/essentials/accelerometer.md
@@ -43,7 +43,7 @@ public class AccelerometerTest
         // Process Acceleration X, Y, and Z
     }
 
-    public void ToggleAcceleromter()
+    public void ToggleAccelerometer()
     {
         try
         {


### PR DESCRIPTION
`public void ToggleAcceleromter` -> `public void ToggleAccelerometer`

Missing `e`.