### PR TITLE
Update automatic-provisioning.md with new alert info.

### DIFF
--- a/docs/ios/get-started/installation/device-provisioning/automatic-provisioning.md
+++ b/docs/ios/get-started/installation/device-provisioning/automatic-provisioning.md
@@ -41,6 +41,10 @@ Before you start the automatic signing process, you should ensure that you have 
 > "authType" : "sa"
 >}
 >```
+Under the same circumstance, you alternatively might be presented with the following alert.
+> ```
+> Authentication Service Is Unavailable
+>```
 
 To automatically sign your app for deployment on an iOS device, do the following:
 

--- a/docs/ios/get-started/installation/device-provisioning/automatic-provisioning.md
+++ b/docs/ios/get-started/installation/device-provisioning/automatic-provisioning.md
@@ -35,16 +35,16 @@ You must also be paired to a Mac build host that has the following:
 Before you start the automatic signing process, you should ensure that you have an Apple ID added in Visual Studio, as described in the [Apple Account Management](~/cross-platform/macios/apple-account-management.md) guide. Once you've added an Apple ID, you can use any associated _Team_. This allows certificates, profiles, and other IDs to be made against the team. The team ID is also used to create a the prefix for an App ID that will be included in the provisioning profile. Having this allows Apple to verify that you are who you say you are.
 
 > [!IMPORTANT]
-> Before you begin, make sure to sign in to either [iTunes Connect](https://itunesconnect.apple.com/) or [appleid.apple.com](https://appleid.apple.com) to check that you have accepted the latest Apple account policies. If prompted, complete the steps to accept any new account agreements from Apple. If you don't accept the privacy agreement from May 2018, you'll get the following alert when trying to provision your device:
+> Before you begin, make sure to sign in to either [iTunes Connect](https://itunesconnect.apple.com/) or [appleid.apple.com](https://appleid.apple.com) to check that you have accepted the latest Apple account policies. If prompted, complete the steps to accept any new account agreements from Apple. If you don't accept the privacy agreement from May 2018, you'll see one of the following alerts when trying to provision your device:
 > ```
 > Unexpected authentication failure. Reason: {
 > "authType" : "sa"
->}
->```
-Under the same circumstance, you alternatively might be presented with the following alert.
+> }
+> ```
+> or
 > ```
 > Authentication Service Is Unavailable
->```
+> ```
 
 To automatically sign your app for deployment on an iOS device, do the following:
 


### PR DESCRIPTION
Add new alert info that demonstrates an alternative message given back by both Visual Studio and Visual Studio for Mac, when automatic provision fails to connect up with Apple due to policy agreements. 

This info was derived by talking with with [James Montemagno](https://twitter.com/JamesMontemagno) and [Pierce Boggan](https://twitter.com/pierceboggan) by way of the thread located at [this link](https://twitter.com/chad_ramos/status/1034544425484136448)