### PR TITLE
Make it more visible if the user needs to reload the project

### DIFF
--- a/docs/android/data-cloud/google-messaging/remote-notifications-with-fcm.md
+++ b/docs/android/data-cloud/google-messaging/remote-notifications-with-fcm.md
@@ -220,10 +220,11 @@ directory of your project:
 3.  Select **google-services.json** in the **Solution Explorer** window.
 
 4.  In the **Properties** pane, set the **Build Action** to
-    **GoogleServicesJson** (if the **GoogleServicesJson** build action is
-    not shown, save and close the Solution, then reopen it):
+    **GoogleServicesJson**:
 
     [![Setting the build action to GoogleServicesJson](remote-notifications-with-fcm-images/04-google-services-json-vs-sml.png)](remote-notifications-with-fcm-images/04-google-services-json-vs.png#lightbox)
+
+> NOTE: if the **GoogleServicesJson** build action is not shown, save and close the Solution, then reopen it
 
 # [Visual Studio for Mac](#tab/vsmac)
 

--- a/docs/android/data-cloud/google-messaging/remote-notifications-with-fcm.md
+++ b/docs/android/data-cloud/google-messaging/remote-notifications-with-fcm.md
@@ -224,7 +224,8 @@ directory of your project:
 
     [![Setting the build action to GoogleServicesJson](remote-notifications-with-fcm-images/04-google-services-json-vs-sml.png)](remote-notifications-with-fcm-images/04-google-services-json-vs.png#lightbox)
 
-> NOTE: if the **GoogleServicesJson** build action is not shown, save and close the Solution, then reopen it
+    > [!NOTE] 
+    > If the **GoogleServicesJson** build action is not shown, save and close the solution, then reopen it.
 
 # [Visual Studio for Mac](#tab/vsmac)
 


### PR DESCRIPTION
We got a feedback ticket because the user didn't realize that he had to close and reopen the 
solution after adding the packages in order for the build action `GooglePlayServicesJson` to 
become available. 

This change makes it more noticeable.

See https://developercommunity.visualstudio.com/content/problem/294192/googleservicesjson-build-action-is-not-available.html