### PR TITLE
Update tabbed page to include TabbedPage.Children

### DIFF
--- a/docs/xamarin-forms/app-fundamentals/navigation/tabbed-page.md
+++ b/docs/xamarin-forms/app-fundamentals/navigation/tabbed-page.md
@@ -62,12 +62,14 @@ The following XAML code example shows a [`TabbedPage`](xref:Xamarin.Forms.Tabbed
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             xmlns:local="clr-namespace:TabbedPageWithNavigationPage;assembly=TabbedPageWithNavigationPage"
             x:Class="TabbedPageWithNavigationPage.MainPage">
-    <local:TodayPage />
-    <NavigationPage Title="Schedule" Icon="schedule.png">
-        <x:Arguments>
-            <local:SchedulePage />
-        </x:Arguments>
-    </NavigationPage>
+    <TabbedPage.Children>
+        <local:TodayPage />
+        <NavigationPage Title="Schedule" Icon="schedule.png">
+            <x:Arguments>
+                <local:SchedulePage />
+            </x:Arguments>
+        </NavigationPage>
+    </TabbedPage.Children>
 </TabbedPage>
 ```
 


### PR DESCRIPTION
I noticed after updating to 3.2.0 that my TabbedPage component which, didn't have a .Children component, was broken. The icons and text would overlap and be positioned incorrectly. Therefore, it seems like .Children is required but the docs don't reference it.