### PR TITLE
Removed Action Not In Screenshot

### DIFF
--- a/docs/ios/user-interface/controls/alerts.md
+++ b/docs/ios/user-interface/controls/alerts.md
@@ -89,8 +89,6 @@ actionSheetButton.TouchUpInside += ((sender, e) => {
 
 	actionSheetAlert.AddAction(UIAlertAction.Create("custom button 1",UIAlertActionStyle.Default, (action) => Console.WriteLine ("Item Two pressed.")));
 
-	actionSheetAlert.AddAction(UIAlertAction.Create("Cancel",UIAlertActionStyle.Default, (action) => Console.WriteLine ("Item Three pressed.")));
-
 	actionSheetAlert.AddAction(UIAlertAction.Create("Cancel",UIAlertActionStyle.Cancel, (action) => Console.WriteLine ("Cancel button pressed.")));
 
 	// Required for iPad - You must specify a source for the Action Sheet since it is


### PR DESCRIPTION
I've just updated the sample code to match the screenshot above. It didn't seem like there would be a lot gained by creating a new screenshot to match the code because there is already a custom button above it. 

This addresses issue #823