### PR TITLE
CHANNEL_ID is not a property of MyFirebaseMessagingService

### DIFF
--- a/docs/android/data-cloud/google-messaging/remote-notifications-with-fcm.md
+++ b/docs/android/data-cloud/google-messaging/remote-notifications-with-fcm.md
@@ -344,7 +344,7 @@ void CreateNotificationChannel()
         return;
     }
 
-    var channel = new NotificationChannel(MyFirebaseMessagingService.CHANNEL_ID,
+    var channel = new NotificationChannel(CHANNEL_ID,
                                           "FCM Notifications",
                                           NotificationImportance.Default)
                   {


### PR DESCRIPTION
The walkthrough suggests having the property 'CHANNEL_ID' in 'MainActivity' class

So code snippet

```csharp
    var channel = new NotificationChannel(MyFirebaseMessagingService.CHANNEL_ID,
                                          "FCM Notifications",
                                          NotificationImportance.Default)
                  {

                      Description = "Firebase Cloud Messages appear in this channel"
                  };
```
where 'MyFirebaseMessagingService' does not come from any reference

is changed to 

```csharp
    var channel = new NotificationChannel(CHANNEL_ID,
                                          "FCM Notifications",
                                          NotificationImportance.Default)
                  {

                      Description = "Firebase Cloud Messages appear in this channel"
                  };
```