### PR TITLE
Added Missing Curly Braces in OnActivityResult

### DIFF
--- a/docs/android/platform/speech.md
+++ b/docs/android/platform/speech.md
@@ -124,24 +124,27 @@ protected override void OnActivityResult(int requestCode, Result resultVal, Inte
         if (resultVal == Result.Ok)
         {
             var matches = data.GetStringArrayListExtra(RecognizerIntent.ExtraResults);
-             if (matches.Count != 0)
-             {
-                  string textInput = textBox.Text + matches[0];
-                  textBox.Text = textInput;
-                  switch(matches[0].Substring(0,5).ToLower())
-                  {
-                     case "north":
-                      MovePlayer(0);
-                     break;
-                   case "south":
-                     MovePlayer(1);
-                     break;
-             }
-             else
-                  textBox.Text = "No speech was recognised";
+            if (matches.Count != 0)
+            {
+                string textInput = textBox.Text + matches[0];
+                textBox.Text = textInput;
+                switch (matches[0].Substring(0, 5).ToLower())
+                {
+                    case "north":
+                        MovePlayer(0);
+                        break;
+                    case "south":
+                        MovePlayer(1);
+                        break;
+                }
+            }
+            else
+            {
+                textBox.Text = "No speech was recognised";
+            }
         }
-   }
-    base.OnActivityResult(requestCode, resultVal, data);
+        base.OnActivityResult(requestCode, resultVal, data);
+    }
 }
 ```
 


### PR DESCRIPTION
There are a couple of missing closing curly braces in the OnActivityResult method. This includes adding the closing one around the else statement, which appears to be consistent with other code sampes within the repository.