### PR TITLE
Correct inaccuracies about UWP implementations

### DIFF
--- a/docs/xamarin-forms/user-interface/slider.md
+++ b/docs/xamarin-forms/user-interface/slider.md
@@ -39,8 +39,8 @@ The `Slider` also defines several properties that affect its appearance:
 
 - [`MinimumTrackColor`](xref:Xamarin.Forms.Slider.MinimumTrackColorProperty) is the bar color on the left side of the thumb.
 - [`MaximumTrackColor`](xref:Xamarin.Forms.Slider.MaximumTrackColorProperty) is the bar color on the right side of the thumb.
-- [`ThumbColor`](xref:Xamarin.Forms.Slider.ThumbColorProperty) is the thumb color. This property is not supported on the Universal Windows Platform.
-- [`ThumbImage`](xref:Xamarin.Forms.Slider.ThumbImageProperty) is the image to use for the thumb, of type [`FileImageSource`](xref:Xamarin.Forms.FileImageSource). This property is not supported on the Universal Windows Platform.
+- [`ThumbColor`](xref:Xamarin.Forms.Slider.ThumbColorProperty) is the thumb color. 
+- [`ThumbImage`](xref:Xamarin.Forms.Slider.ThumbImageProperty) is the image to use for the thumb, of type [`FileImageSource`](xref:Xamarin.Forms.FileImageSource). 
 
 > [!NOTE]
 > The `ThumbColor` and `ThumbImage` properties are mutually exclusive. If both properties are set, the `ThumbImage` property will take precedence.
@@ -287,8 +287,6 @@ The Android implementation of `Slider` is based on the Android [`SeekBar`](https
 The UWP implementation of `Slider` is based on the UWP [`Slider`](/uwp/api/windows.ui.xaml.controls.slider) control. The `StepFrequency` property of the UWP `Slider` is set to the difference of the `Maximum` and `Minimum` properties divided by 10, but not greater than 1.
 
 For example, for the default range of 0 to 1, the `StepFrequency` property is set to 0.1. As the `Slider` is manipulated, the `Value` property is restricted to 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, and 1.0. (This is evident in the last page in the [**SliderDemos**](https://developer.xamarin.com/samples/xamarin-forms/UserInterface/SliderDemos) sample.) When the difference between the `Maximum` and `Minimum` properties is 10 or greater, then `StepFrequency` is set to 1, and the `Value` property has integral values.
-
-In addition, the [`ThumbColor`](xref:Xamarin.Forms.Slider.ThumbColorProperty) and [`ThumbImage`](xref:Xamarin.Forms.Slider.ThumbImageProperty) properties are not supported on UWP.
 
 ### The StepSlider solution
 


### PR DESCRIPTION
The `ThumbColor` and `ThumbImage` properties have been available on UWP since Xamarin.Forms 3.1.0.