### PR TITLE
Fix typo ("it's" -> "its")

### DIFF
--- a/docs/xamarin-forms/user-interface/colors.md
+++ b/docs/xamarin-forms/user-interface/colors.md
@@ -48,7 +48,7 @@ These colors are shown on each platform below. Notice the final color - `Accent`
 
 Use the `Default` to set (or re-set) a color value back to the platform default (understanding that this represents a different underlying color on each platform for each property).
 
-Developers can use this value to set a `Color` property but should **not** query this instance for it's component RGB values (they're all set to -1).
+Developers can use this value to set a `Color` property but should **not** query this instance for its component RGB values (they're all set to -1).
 
 ## Color.Transparent
 


### PR DESCRIPTION
"for it's component RGB values" -> "for its component RGB values"