### PR TITLE
Removed the anchor tag for section heading

### DIFF
--- a/docs/xamarin-forms/user-interface/styles/xaml/dynamic.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/dynamic.md
@@ -117,8 +117,6 @@ public class DynamicStylesPageCS : ContentPage
 
 In C#, the [`SearchBar`](xref:Xamarin.Forms.SearchBar) instances use the [`SetDynamicResource`](xref:Xamarin.Forms.Element.SetDynamicResource*) method to reference `searchBarStyle`. The `OnButtonClicked` event handler code is identical to the XAML example, and when executed, `searchBarStyle` will switch between `blueSearchBarStyle` and `greenSearchBarStyle`.
 
-<a name="dynamic-style-inheritance">
-
 ## Dynamic Style Inheritance
 
 Deriving a style from a dynamic style can't be achieved using the [`Style.BasedOn`](xref:Xamarin.Forms.Style.BasedOn) property. Instead, the [`Style`](xref:Xamarin.Forms.Style) class includes the [`BaseResourceKey`](xref:Xamarin.Forms.Style.BaseResourceKey) property, which can be set to a dictionary key whose value might dynamically change.


### PR DESCRIPTION
Addresses issue #901 

I don't see any other uses of an inline anchor tags in this documentation or others, and my understanding is that with markdown the headings automatically become inline anchors when they are rendered so this doesn't seem necessary any longer. It was also causing the page to render with a link for the header and the first sentence until it hit the next anchor.

There is a reference to this heading from the [device](https://github.com/MicrosoftDocs/xamarin-docs/blob/live/docs/xamarin-forms/user-interface/styles/xaml/device.md) file in the same location which would just need to be verified that this still works as intended.