### PR TITLE
Fix Android platform version check usage

### DIFF
--- a/docs/android/app-fundamentals/notifications/local-notifications.md
+++ b/docs/android/app-fundamentals/notifications/local-notifications.md
@@ -1138,7 +1138,7 @@ conditionally call `SetCategory` when the API level is equal to or
 greater than Android 5.0 (API level 21):
 
 ```csharp
-if ((int) Android.OS.Build.Version.SdkInt >= BuildVersionCodes.Lollipop) {
+if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop) {
     builder.SetCategory (Notification.CategoryEmail);
 }
 ```
@@ -1160,7 +1160,7 @@ can check the API level at runtime and call `SetVisiblity` only when it
 is available:
 
 ```csharp
-if ((int) Android.OS.Build.Version.SdkInt >= 21) {
+if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop) {
     builder.SetVisibility (Notification.Public);
 }
 ```

--- a/docs/xamarin-forms/user-interface/themes/custom.md
+++ b/docs/xamarin-forms/user-interface/themes/custom.md
@@ -205,7 +205,7 @@ namespace ThemesDemo.Droid
 
         protected override bool CanBeApplied()
         {
-            return Container != null && (int)Android.OS.Build.VERSION.SdkInt >= 21;
+            return Container != null && Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop;
         }
 
         protected override void OnAttachedInternal()


### PR DESCRIPTION
* Incorrect usage of `Version` vs correct `VERSION`
* Removed the need to cast to int and compare with int as opposed to named enum