### PR TITLE
Correct bug reporting links from bugzilla to GitHub

### DIFF
--- a/docs/android/troubleshooting/errors.md
+++ b/docs/android/troubleshooting/errors.md
@@ -35,7 +35,7 @@ This document provides some information on the various error codes from Xamarin.
 
 |Error Code|Description|
 |--- |--- |
-|XA0000|Unexpected error - Please fill a [bug report](http://bugzilla.xamarin.com).|
+|XA0000|Unexpected error - Please fill a [bug report](https://github.com/xamarin/xamarin-android/issues/new).|
 |XA0001|'-devname was provided without any device-specific action.|
 |XA0002|Could not parse the environment variable '{0}'.|
 |XA0003|Application name '{0}.exe' conflicts with an SDK or product assembly (.dll) name.|

--- a/docs/ios/deploy-test/linker.md
+++ b/docs/ios/deploy-test/linker.md
@@ -67,7 +67,7 @@ performance reasons this is the default setting when your IDE targets
 for the iOS simulator. For devices builds this should only be used as
 a workaround whenever the linker contains a bug that prevents your
 application to run. If your application only works with *-nolink*,
-please submit a [bug report](http://bugzilla.xamarin.com).
+please submit a [bug report](https://github.com/xamarin/xamarin-macios/issues/new).
 
 This corresponds to the *-nolink* option when using the command-line
 tool mtouch.

--- a/docs/ios/troubleshooting/mtouch-errors.md
+++ b/docs/ios/troubleshooting/mtouch-errors.md
@@ -23,9 +23,9 @@ E.g. parameters, environment, missing tools.
 
 <a name="MT0000" />
 
-### MT0000: Unexpected error - Please fill a bug report at http://bugzilla.xamarin.com
+### MT0000: Unexpected error - Please fill a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 
-An unexpected error condition occurred. Please [file a bug report](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS) with as much information as possible, including:
+An unexpected error condition occurred. Please [file a bug report](https://github.com/xamarin/xamarin-macios/issues/new) with as much information as possible, including:
 
 * Full build logs, with maximum verbosity (e.g. `-v -v -v -v` in the **Additional mtouch arguments**);
 * A minimal test case that reproduce the error; and

--- a/docs/ios/tvos/troubleshooting.md
+++ b/docs/ios/tvos/troubleshooting.md
@@ -27,7 +27,7 @@ The current release of Xamarin's tvOS support has the following known issues:
 	- **Potential Workaround** – Downgrade the Mono framework version available in our Stable channel.
 - **Xamarin Visual Studio & Xamarin.iOS** – When deploying WatchKit applications in Visual studio, the error `The file ‘bin\iPhoneSimulator\Debug\WatchKitApp1WatchKitApp.app\WatchKitApp1WatchKitApp’ does not exist` may appear.
 
-Please report any bugs you find to [Bugzilla](https://bugzilla.xamarin.com/enter_bug.cgi?product=iOS).
+Please report any bugs you find on [GitHub](https://github.com/xamarin/xamarin-macios/issues/new).
 
 ## Troubleshooting
 

--- a/docs/ios/watchos/get-started/installation.md
+++ b/docs/ios/watchos/get-started/installation.md
@@ -209,7 +209,7 @@ The following error will appear in the **Application Output** if you try to
 launch to a simulator that does not have a paired watch:
 
 ```csharp
-error MT0000: Unexpected error - Please file a bug report at http://bugzilla.xamarin.com
+error MT0000: Unexpected error - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 error HE0020: Could not find a paired Watch device for the iOS device 'iPhone 6'.
 ```
 

--- a/docs/mac/troubleshooting/mmp-errors.md
+++ b/docs/mac/troubleshooting/mmp-errors.md
@@ -18,9 +18,9 @@ E.g. parameters, environment, missing tools.
 
 <a name="MM0000" />
 
-#### MM0000: Unexpected error - Please file a bug report at http://bugzilla.xamarin.com
+#### MM0000: Unexpected error - Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
 
-An unexpected error condition occurred. Please [file a bug report](https://bugzilla.xamarin.com/enter_bug.cgi?product=Xamarin.Mac) with as much information as possible, including:
+An unexpected error condition occurred. Please [file a bug report](https://github.com/xamarin/xamarin-macios/issues/new) with as much information as possible, including:
 
 * Full build logs, with maximum verbosity (e.g. `-v -v -v -v` in the **Additional mmp arguments**);
 * A minimal test case that reproduce the error; and


### PR DESCRIPTION
Lots of docs still point to bugzilla when instructing to report issues, this corrects all the instances of this that I found.