### PR TITLE
Changed ShowSettingsUI to OpenSettings

### DIFF
--- a/docs/essentials/app-information.md
+++ b/docs/essentials/app-information.md
@@ -49,7 +49,7 @@ The **AppInfo** class can also display a page of settings maintained by the oper
 
 ```csharp
 // Display settings page
-AppInfo.ShowSettingsUI();
+AppInfo.OpenSettings();
 ```
 
 This settings page allows the user to change application permissions and perform other platform-specific tasks.


### PR DESCRIPTION
Per the API docs, this should be `OpenSettings()` instead of `ShowSettingsUI()`.

Addresses #1126