### PR TITLE
Fixed a typo in the Grid article

### DIFF
--- a/docs/xamarin-forms/user-interface/layouts/grid.md
+++ b/docs/xamarin-forms/user-interface/layouts/grid.md
@@ -167,8 +167,8 @@ In C#:
 
 ```csharp
 var grid = new Grid { ColumnSpacing = 5 };
-grid.ColumnDefnitions.Add(new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star)});
-grid.ColumnDefnitions.Add(new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star)});
+grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star)});
+grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star)});
 ```
 
 ### Spans


### PR DESCRIPTION
In one of the code samples, _ColumnDefinitions_ property of the Grid was mistyped as _ColumnDefnitions_.