### PR TITLE
Fix incorrect casing of an example variable

### DIFF
--- a/docs/android/platform/fingerprint-authentication/scanning.md
+++ b/docs/android/platform/fingerprint-authentication/scanning.md
@@ -31,7 +31,7 @@ protected void FingerPrintAuthenticationExample()
     // cancellationSignal can be used to manually stop the fingerprint scanner. 
     cancellationSignal = new Android.Support.V4.OS.CancellationSignal();
     
-    FingerprintManagerCompat fingerPrintManager = FingerprintManagerCompat.From(this);
+    FingerprintManagerCompat fingerprintManager = FingerprintManagerCompat.From(this);
     
     // AuthenticationCallback is a base class that will be covered later on in this guide.
     FingerprintManagerCompat.AuthenticationCallback authenticationCallback = new MyAuthCallbackSample(this);


### PR DESCRIPTION
Changed to match the casing used later in the example.