### PR TITLE
Updating Spacing on Code Examples

### DIFF
--- a/docs/ios/user-interface/controls/creating-tabbed-applications.md
+++ b/docs/ios/user-interface/controls/creating-tabbed-applications.md
@@ -301,12 +301,12 @@ There are a few important steps to note when adding a Storyboard to a previously
 	[![](creating-tabbed-applications-images/project-options.png "Set the Main Interface to MainStoryboard")](creating-tabbed-applications-images/project-options.png#lightbox)
 1. In your `App Delegate`, override the Window method, with the following code:
 
-```csharp
-public override UIWindow Window {
-    get;
-    set;
-}
-```
+	```csharp
+	public override UIWindow Window {
+	    get;
+	    set;
+	}
+	```
 
 We are going to need three View Controllers for this example. One, named `ViewController1`, will be used as our Initial View Controller and in the first tab. The other two, named `ViewController2` and `ViewController3`, which will be used in the second and third tabs respectively.
 

--- a/docs/ios/user-interface/controls/creating-tabbed-applications.md
+++ b/docs/ios/user-interface/controls/creating-tabbed-applications.md
@@ -100,31 +100,31 @@ using System;
 using UIKit;
 
 namespace TabbedApplication {
-        public class TabController : UITabBarController {
+    public class TabController : UITabBarController {
 
-                UIViewController tab1, tab2, tab3;
+        UIViewController tab1, tab2, tab3;
 
-                public TabController ()
-                {
-			tab1 = new UIViewController();
-                        tab1.Title = "Green";
-                        tab1.View.BackgroundColor = UIColor.Green;
+        public TabController ()
+        {
+            tab1 = new UIViewController();
+            tab1.Title = "Green";
+            tab1.View.BackgroundColor = UIColor.Green;
 
-                        tab2 = new UIViewController();
-                        tab2.Title = "Orange";
-                        tab2.View.BackgroundColor = UIColor.Orange;
+            tab2 = new UIViewController();
+            tab2.Title = "Orange";
+            tab2.View.BackgroundColor = UIColor.Orange;
 
-                        tab3 = new UIViewController();
-                        tab3.Title = "Red";
-                        tab3.View.BackgroundColor = UIColor.Red;
+            tab3 = new UIViewController();
+            tab3.Title = "Red";
+            tab3.View.BackgroundColor = UIColor.Red;
 
-                        var tabs = new UIViewController[] {
-                                tab1, tab2, tab3
-                        };
+            var tabs = new UIViewController[] {
+                tab1, tab2, tab3
+            };
 
-                        ViewControllers = tabs;
-                }
+            ViewControllers = tabs;
         }
+    }
 }
 ```
 
@@ -147,20 +147,20 @@ following code for the `AppDelegate`:
 [Register ("AppDelegate")]
 public partial class AppDelegate : UIApplicationDelegate
 {
-	UIWindow window;
-	TabController tabController;
-
-	public override bool FinishedLaunching (UIApplication app, NSDictionary options)
-	{
-		window = new UIWindow (UIScreen.MainScreen.Bounds);
-
-		tabController = new TabController ();
-		window.RootViewController = tabController;
-
-		window.MakeKeyAndVisible ();
-
-		return true;
-	}
+    UIWindow window;
+    TabController tabController;
+    
+    public override bool FinishedLaunching (UIApplication app, NSDictionary options)
+    {
+        window = new UIWindow (UIScreen.MainScreen.Bounds);
+        
+        tabController = new TabController ();
+        window.RootViewController = tabController;
+        
+        window.MakeKeyAndVisible ();
+        
+        return true;
+    }
 }
 ```
 
@@ -301,12 +301,12 @@ There are a few important steps to note when adding a Storyboard to a previously
 	[![](creating-tabbed-applications-images/project-options.png "Set the Main Interface to MainStoryboard")](creating-tabbed-applications-images/project-options.png#lightbox)
 1. In your `App Delegate`, override the Window method, with the following code:
 
-	```csharp
-	public override UIWindow Window {
-	  get;
-	  set;
-	}
-	```
+```csharp
+public override UIWindow Window {
+    get;
+    set;
+}
+```
 
 We are going to need three View Controllers for this example. One, named `ViewController1`, will be used as our Initial View Controller and in the first tab. The other two, named `ViewController2` and `ViewController3`, which will be used in the second and third tabs respectively.
 
@@ -356,7 +356,7 @@ We now need to tell the View Controller to hide the button when the event fires 
 ```csharp
 partial void InitialActionCompleted (UIButton sender)
 {
-	aButton.Hidden = true;  
+    aButton.Hidden = true;  
 }
 ```
 
@@ -395,9 +395,9 @@ If we save and run the application now, we'll find that the button reappears whe
 ```csharp
 public override void ViewDidLoad ()
 {
-     if (ParentViewController != null){
-       aButton.Hidden = true;
-     }
+    if (ParentViewController != null){
+        aButton.Hidden = true;
+    }
 }
 ```
 


### PR DESCRIPTION
Based on the last pull request #1177 and the comments from @conceptdev I've updated the formatting of the code blocks on this page to reflect the contribution guidelines, removing the tabs and making everything indented four spaces for consistency.