### PR TITLE
Fix incorrect closing tag for ShellItem in example

### DIFF
--- a/docs/xamarin-forms/app-fundamentals/shell.md
+++ b/docs/xamarin-forms/app-fundamentals/shell.md
@@ -92,7 +92,7 @@ The following XAML shows a simple example of a `Shell` file:
                 <local:HomePage />
             </ShellContent>
         </ShellSection>
-    <ShellItem>
+    </ShellItem>
 </Shell>
 ```
 


### PR DESCRIPTION
"<ShellItem>" -> "</ShellItem>"