### PR TITLE
Update introduction-to-xamarin-forms.md

### DIFF
--- a/docs/xamarin-forms/get-started/introduction-to-xamarin-forms.md
+++ b/docs/xamarin-forms/get-started/introduction-to-xamarin-forms.md
@@ -421,7 +421,7 @@ class EmployeeCell : ViewCell
         var twitterLabel = new Label
         {
            HorizontalOptions = LayoutOptions.FillAndExpand,
-           Font = Fonts.Twitter
+           FontSize = 24
         };
         twitterLabel.SetBinding(Label.TextProperty, "Twitter");
 


### PR DESCRIPTION
'Label.Font' is obsolete: 'Font is obsolete as of version 1.3.0. Please use the Font attributes which are on the class itself'.