### PR TITLE
Update enhanced-user-notifications.md

### DIFF
--- a/docs/ios/platform/user-notifications/enhanced-user-notifications.md
+++ b/docs/ios/platform/user-notifications/enhanced-user-notifications.md
@@ -269,7 +269,7 @@ UNUserNotificationCenter.Current.AddNotificationRequest (request, (err) => {
 
 ## Handling Foreground App Notifications
 
-New to iOS 10, an app can handle Notifications differently when it is in the foreground and a Notification is triggered. By providing a `UNUserNotificationCenterDelegate` and implementing the `UserNotificationCenter` method, the app can take over responsibility for displaying the Notification. For example:
+New to iOS 10, an app can handle Notifications differently when it is in the foreground and a Notification is triggered. By providing a `UNUserNotificationCenterDelegate` and implementing the `WillPresentNotification` method, the app can take over responsibility for displaying the Notification. For example:
 
 ```csharp
 using System;


### PR DESCRIPTION
Wrong name of method was used in text.

But that being said, I'm not fully fond of the entire sentence:  "By providing a `UNUserNotificationCenterDelegate` and implementing the `WillPresentNotification` method, the app can take over responsibility for displaying the Notification."
I'd prefer something like: "... Notification is triggered. By creating a custom `UNUserNotificationCenterDelegate` and overriding the  `WillPresentNotification` method, the app can take over responsibility for displaying the Notification."