### PR TITLE
Fix grid tutorial 404

### DIFF
--- a/docs/get-started/index.yml
+++ b/docs/get-started/index.yml
@@ -105,7 +105,7 @@ sections:
       image:
         src: https://docs.microsoft.com/media/common/i_account-management.svg
       title: Image
-    - href: /tutorials/grid/
+    - href: tutorials/grid/
       html: <p></p>
       image:
         src: https://docs.microsoft.com/media/common/i_table.svg


### PR DESCRIPTION
The getting started page 404s when clicking the "grid" panel under tutorials.