### PR TITLE
Typo fix: "is used to encrypted values securely"

### DIFF
--- a/docs/essentials/secure-storage.md
+++ b/docs/essentials/secure-storage.md
@@ -148,7 +148,7 @@ In some cases KeyChain data is synchronized with iCloud, and uninstalling the ap
 
 # [UWP](#tab/uwp)
 
-[DataProtectionProvider](https://docs.microsoft.com/uwp/api/windows.security.cryptography.dataprotection.dataprotectionprovider) is used to encrypted values securely on UWP devices.
+[DataProtectionProvider](https://docs.microsoft.com/uwp/api/windows.security.cryptography.dataprotection.dataprotectionprovider) is used to encrypt values securely on UWP devices.
 
 Encrypted values are stored in `ApplicationData.Current.LocalSettings`, inside a container with a name of **[YOUR-APP-ID].xamarinessentials**.
 


### PR DESCRIPTION
"is used to **encrypted** values securely" -> "is used to **encrypt** values securely"