### PR TITLE
Updated link to article about memory management

### DIFF
--- a/docs/ios/deploy-test/performance.md
+++ b/docs/ios/deploy-test/performance.md
@@ -228,7 +228,7 @@ class MyChild : UIView
 For more information about releasing strong references, see
 [Release IDisposable Resources](~/cross-platform/deploy-test/memory-perf-best-practices.md#idisposable).
 There's also a good discussion in this blog post:
-[Xamarin.iOS, the garbage collector and me](http://krumelur.me/2015/04/27/xamarin-ios-the-garbage-collector-and-me/).
+[Xamarin.iOS, the garbage collector and me](http://c-sharx.net/2015-04-27-xamarin-ios-the-garbage-collector-and-me).
 
 ### More information
 


### PR DESCRIPTION
Updated link to the to "Xamarin.iOS, the garbage collector and me" article. The old link was redirected to the main page of the blog, not the the article in question.