### PR TITLE
Update hello-ios-quickstart.md

### DIFF
--- a/docs/ios/get-started/hello-ios/hello-ios-quickstart.md
+++ b/docs/ios/get-started/hello-ios/hello-ios-quickstart.md
@@ -21,7 +21,7 @@ This guide describes how to create an application that translates an alphanumeri
 
 iOS development with Xamarin requires:
 
-- A Mac running macOS HIgh Sierra (10.13) or above.
+- A Mac running macOS High Sierra (10.13) or above.
 - Latest version of Xcode and iOS SDK installed from the [App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) .
 
 ::: zone pivot="macos"


### PR DESCRIPTION
Fixed typo in ## Requirements: "macOS HLgh Sierra" to "macOS High Sierra"