### PR TITLE
Clarify what kind of key is meant in the Secure Storage page of the Xamarin.Essentials

### DIFF
--- a/docs/essentials/secure-storage.md
+++ b/docs/essentials/secure-storage.md
@@ -128,7 +128,7 @@ SecureStorage.RemoveAll();
 
 # [Android](#tab/android)
 
-The [Android KeyStore](https://developer.android.com/training/articles/keystore.html) is used to store the cipher key used to encrypt the value before it is saved into a [Shared Preferences](https://developer.android.com/training/data-storage/shared-preferences.html) with a filename of **[YOUR-APP-PACKAGE-ID].xamarinessentials**.  The key used in the shared preferences file is a _MD5 Hash_ of the key passed into the `SecureStorage` APIs.
+The [Android KeyStore](https://developer.android.com/training/articles/keystore.html) is used to store the cipher key used to encrypt the value before it is saved into a [Shared Preferences](https://developer.android.com/training/data-storage/shared-preferences.html) with a filename of **[YOUR-APP-PACKAGE-ID].xamarinessentials**.  The key (not a cryptographic key, the _key_ to the _value_) used in the shared preferences file is a _MD5 Hash_ of the key passed into the `SecureStorage` APIs.
 
 ## API Level 23 and Higher
 


### PR DESCRIPTION
I didn't understand how the Secure Storage worked on Android, I glanced over the description a couple of times, and I even opened the source. That made me realize that the _key_ in that section is about the _key_ to the _value_, and not a cryptographic key.

Since that section is mostly about cryptography, I think many people will fall into the same trap. I don't know if this is the best clarification, so open to any other suggestions.