### PR TITLE
Link to class

### DIFF
--- a/docs/xamarin-forms/user-interface/layouts/stack-layout.md
+++ b/docs/xamarin-forms/user-interface/layouts/stack-layout.md
@@ -13,7 +13,7 @@ ms.date: 11/25/2015
 
 [![Download Sample](~/media/shared/download.png) Download the sample](https://developer.xamarin.com/samples/xamarin-forms/UserInterface/Layout/)
 
-[`StackLayout`](xref:Xamarin.Forms.StackLayout) organizes views in a one-dimensional line ("stack"), either horizontally or vertically. Views in a `StackLayout` can be sized based on the space in the layout using layout options. Positioning is determined by the order views were added to the layout and the layout options of the views.
+[StackLayout](xref:Xamarin.Forms.StackLayout) organizes views in a one-dimensional line ("stack"), either horizontally or vertically. Views in a `StackLayout` can be sized based on the space in the layout using layout options. Positioning is determined by the order views were added to the layout and the layout options of the views.
 
 [![](stack-layout-images/layouts-sml.png "Xamarin.Forms Layouts")](stack-layout-images/layouts.png#lightbox "Xamarin.Forms Layouts")
 

--- a/docs/xamarin-forms/user-interface/layouts/stack-layout.md
+++ b/docs/xamarin-forms/user-interface/layouts/stack-layout.md
@@ -13,7 +13,7 @@ ms.date: 11/25/2015
 
 [![Download Sample](~/media/shared/download.png) Download the sample](https://developer.xamarin.com/samples/xamarin-forms/UserInterface/Layout/)
 
-`StackLayout` organizes views in a one-dimensional line ("stack"), either horizontally or vertically. Views in a `StackLayout` can be sized based on the space in the layout using layout options. Positioning is determined by the order views were added to the layout and the layout options of the views.
+[`StackLayout`](xref:Xamarin.Forms.StackLayout) organizes views in a one-dimensional line ("stack"), either horizontally or vertically. Views in a `StackLayout` can be sized based on the space in the layout using layout options. Positioning is determined by the order views were added to the layout and the layout options of the views.
 
 [![](stack-layout-images/layouts-sml.png "Xamarin.Forms Layouts")](stack-layout-images/layouts.png#lightbox "Xamarin.Forms Layouts")
 


### PR DESCRIPTION
There was no link to the docs for the `StackLayout` class like there is for the classes of other layouts elsewhere. Such a link is nice and handy.