### PR TITLE
Missing characters

### DIFF
--- a/docs/ios/platform/introduction-to-ios12/arkit2.md
+++ b/docs/ios/platform/introduction-to-ios12/arkit2.md
@@ -294,7 +294,7 @@ ARKit 2 supports "environmental texturing" that uses captured imagery to estimat
 In order to use environmental texturing:
 
 * Your [`SCNMaterial`](xref:SceneKit.SCNMaterial) objects must use [`SCNLightingModel.PhysicallyBased`](xref:SceneKit.SCNLightingModel.PhysicallyBased) and assign a value in the range of 0 to 1 for [`Metalness.Contents`](xref:SceneKit.SCNMaterial.Metalness) and [`Roughness.Contents`](xref:SceneKit.SCNMaterialProperty.Contents) and
-* Your tracking configuration must set [`EnvironmentTexturing`](xref:ARKit.ARWorldTrackingConfiguration.EnvironmentTexturing) = [AREnvironmentTexturing.Automatic`](xref:ARKit.AREnvironmentTexturing.Automatic) :
+* Your tracking configuration must set [`EnvironmentTexturing`](xref:ARKit.ARWorldTrackingConfiguration.EnvironmentTexturing) = [`AREnvironmentTexturing.Automatic`](xref:ARKit.AREnvironmentTexturing.Automatic) :
 
 ```csharp
 var sphere = SCNSphere.Create(0.33F);
@@ -317,7 +317,7 @@ Although the perfectly reflective texture shown in the preceding code snippet is
 
 ### Shared and persistent AR experiences
 
-Another major addition to ARKit 2 is the [`ARWorldMap`](xref:ARKit.ARWorldMap) class, which allows you to share or store world-tracking data. You get the current world map with [`ARSession.GetCurrentWorldMapAsync`](xref:ARKit.ARSession.GetCurrentWorldMapAsync) or [`GetCurrentWorldMap(Action<ARWorldMap,NSError>`](xref:ARKit.ARSession.GetCurrentWorldMap(System.Action{ARKit.ARWorldMap,Foundation.NSError})) :
+Another major addition to ARKit 2 is the [`ARWorldMap`](xref:ARKit.ARWorldMap) class, which allows you to share or store world-tracking data. You get the current world map with [`ARSession.GetCurrentWorldMapAsync`](xref:ARKit.ARSession.GetCurrentWorldMapAsync) or [`GetCurrentWorldMap(Action<ARWorldMap,NSError>)`](xref:ARKit.ARSession.GetCurrentWorldMap(System.Action{ARKit.ARWorldMap,Foundation.NSError})) :
 
 ```csharp
 // Local storage


### PR DESCRIPTION
Added two missing characters so that one of the code blocks was rendered properly and one method call was properly closed with a parenthesis.