### PR TITLE
Xamarin.Android docs for CPU architectures

### DIFF
--- a/docs/android/app-fundamentals/cpu-architectures.md
+++ b/docs/android/app-fundamentals/cpu-architectures.md
@@ -6,7 +6,7 @@ ms.assetid: D4BC889D-9164-49BB-9B7B-F6C4E4E109F1
 ms.technology: xamarin-android
 author: conceptdev
 ms.author: crdun
-ms.date: 03/01/2018
+ms.date: 05/30/2019
 ---
 
 # CPU Architectures
@@ -71,7 +71,7 @@ Xamarin.Android supports the following architectures:
     devices.
 
 > [!NOTE]
-> As of [Xamarin.Android 9.2](https://docs.microsoft.com/en-us/xamarin/android/release-notes/9/9.2#removal-of-support-for-armeabi-cpu-architecture), `armeabi` is no longer supported.
+> As of [Xamarin.Android 9.2](https://docs.microsoft.com/xamarin/android/release-notes/9/9.2#removal-of-support-for-armeabi-cpu-architecture), `armeabi` is no longer supported.
 
 -   **armeabi-v7a** &ndash; ARM-based CPUs with hardware floating-point operations
     and multiple CPU (SMP) devices. Note that `armeabi-v7a` machine code will not

--- a/docs/android/app-fundamentals/cpu-architectures.md
+++ b/docs/android/app-fundamentals/cpu-architectures.md
@@ -70,6 +70,9 @@ Xamarin.Android supports the following architectures:
     set. Note that `armeabi` is not thread-safe and should not be used on multi-CPU
     devices.
 
+> [!NOTE]
+> As of [Xamarin.Android 9.2](https://docs.microsoft.com/en-us/xamarin/android/release-notes/9/9.2#removal-of-support-for-armeabi-cpu-architecture), `armeabi` is no longer supported.
+
 -   **armeabi-v7a** &ndash; ARM-based CPUs with hardware floating-point operations
     and multiple CPU (SMP) devices. Note that `armeabi-v7a` machine code will not
     run on ARMv5 devices.
@@ -106,8 +109,7 @@ the [Nexus 9](http://www.google.com/nexus/9/)) can run apps configured for
 make it possible for your app to address more memory.
 
 > [!NOTE]
-> 64-bit runtime support is currently an experimental
-> feature. Remember that 64-bit runtimes are *not* required to run your app on 64-bit devices. 
+> From August 2018 new apps will be required to target API level 26, and from August 2019 apps will be [required to provide 64-bit versions](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html) in addition to the 32-bit version.
 
 ## Additional Information
 

--- a/docs/android/deploy-test/multicore-devices.md
+++ b/docs/android/deploy-test/multicore-devices.md
@@ -76,8 +76,8 @@ software helper functions that come from the compiler's `libgcc.a`
 static library. SMP devices are not supported by `armeabi`.
 
 **Note**: Xamarin.Android's `armeabi` code is not thread safe and
-should not be used on multi-CPU `armeabi-v7a`devices (described
-below). Using `aremabi` code on a single-core `armeabi-v7a` device is
+should not be used on multi-CPU `armeabi-v7a` devices (described
+below). Using `armeabi` code on a single-core `armeabi-v7a` device is
 safe.
 
 #### armeabi-v7a
@@ -118,15 +118,6 @@ This is the name of an ABI for CPUs that support the 64-bit x86
 instruction set (also referred to as *x64* or *AMD64*). Xamarin.Android
 5.1 provides experimental support for this architecture (for more
 information, see [Experimental Features](https://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#Experimental_Features)).
-
-#### mips
-
-This is the name of an ABI for MIPS-based CPUs that support at least
-the `MIPS32r1` instruction set. Neither MIPS 16 nor `micromips` are
-supported by Android.
-
-**Note:** MIPS devices are not currently supported by Xamarin.Android,
-but will be in a future release.
 
 #### APK File Format
 
@@ -313,9 +304,12 @@ $APP/lib/libtwo.so # from armeabi-v7a
 
 Xamarin.Android supports the following architectures:
 
-- `armeabi`
+- *`armeabi`
 - `armeabi-v7a`
 - `x86`
+
+> [!NOTE]
+> As of [Xamarin.Android 9.2](https://docs.microsoft.com/en-us/xamarin/android/release-notes/9/9.2#removal-of-support-for-armeabi-cpu-architecture), `armeabi` is no longer supported.
 
 Xamarin.Android provides experimental support for the following architectures:
 
@@ -365,7 +359,6 @@ are intended only for `armeabi`.
 
 ## Related Links
 
-- [MIPS Architecture](http://www.mips.com/products/product-materials/processor/mips-architecture)
 - [ABI for the ARM Architecture (PDF)](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0036b/IHI0036B_bsabi.pdf)
 - [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html)
 - [Issue 9089:Nexus One - Won't load ANY native libraries from armeabi if there's at least one library at armeabi-v7a](http://code.google.com/p/android/issues/detail?id=9089)

--- a/docs/android/deploy-test/multicore-devices.md
+++ b/docs/android/deploy-test/multicore-devices.md
@@ -6,7 +6,7 @@ ms.assetid: D812883C-A14A-E74B-0F72-E50071E96328
 ms.technology: xamarin-android
 author: conceptdev
 ms.author: crdun
-ms.date: 02/05/2018
+ms.date: 05/30/2019
 ---
 
 # Multi-Core Devices & Xamarin.Android
@@ -94,9 +94,9 @@ performance improvements over an application that uses `armeabi`.
 
 This is a 64-bit instruction set that is based on the ARMv8 CPU
 architecture. This architecture is used in the *Nexus 9*.
-Xamarin.Android 5.1 provides experimental support for
+Xamarin.Android 5.1 introduced support for
 this architecture (for more information, see
-[Experimental Features](https://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#Experimental_Features)).
+[64-bit runtime support](https://github.com/xamarin/release-notes-archive/blob/master/release-notes/android/xamarin.android_5/xamarin.android_5.1/index.md#64-bit-runtime-support)).
 
 #### x86
 
@@ -116,8 +116,8 @@ extensions such as:
 
 This is the name of an ABI for CPUs that support the 64-bit x86
 instruction set (also referred to as *x64* or *AMD64*). Xamarin.Android
-5.1 provides experimental support for this architecture (for more
-information, see [Experimental Features](https://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#Experimental_Features)).
+5.1 introduced support for this architecture (for more
+information, see [64-bit runtime support](https://github.com/xamarin/release-notes-archive/blob/master/release-notes/android/xamarin.android_5/xamarin.android_5.1/index.md#64-bit-runtime-support)).
 
 #### APK File Format
 
@@ -302,22 +302,22 @@ $APP/lib/libtwo.so # from armeabi-v7a
 
 ### Xamarin.Android and ABIs
 
-Xamarin.Android supports the following architectures:
-
-- *`armeabi`
-- `armeabi-v7a`
-- `x86`
-
-> [!NOTE]
-> As of [Xamarin.Android 9.2](https://docs.microsoft.com/en-us/xamarin/android/release-notes/9/9.2#removal-of-support-for-armeabi-cpu-architecture), `armeabi` is no longer supported.
-
-Xamarin.Android provides experimental support for the following architectures:
+Xamarin.Android supports the following _64-bit_ architectures:
 
 - `arm64-v8a`
 - `x86_64`
 
 > [!NOTE]
 > From August 2018 new apps will be required to target API level 26, and from August 2019 apps will be [required to provide 64-bit versions](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html) in addition to the 32-bit version.
+
+Xamarin.Android supports these 32-bit architectures:
+
+- `armeabi` ^
+- `armeabi-v7a`
+- `x86`
+
+> [!NOTE]
+> **^** As of [Xamarin.Android 9.2](https://docs.microsoft.com/xamarin/android/release-notes/9/9.2#removal-of-support-for-armeabi-cpu-architecture), `armeabi` is no longer supported.
 
 Xamarin.Android does not currently provide support for `mips`.
 
@@ -331,7 +331,6 @@ set in the **Android Options** page of project **Properties**, under
 the **Advanced** tab, as shown in the following screenshot:
 
 ![Android Options Advanced properties](multicore-devices-images/vs-abi-selections.png)
-
 
 In Visual Studio for Mac, the supported architectures may be selected on the
 **Android Build** page of **Project Options**, under the **Advanced**


### PR DESCRIPTION
A few updates needed here:

* We can drop anything mentioning MIPS. It's dead and not supported.
* We had a spot that said 64-bit bit support was experimental! It is
  in fact, stable and required by Google Play now!
* We should keep the docs here about `armeabi`, but it is no longer
  supported with Xamarin.Android 9.2 and higher. At some point when VS
  2017 is out of the picture, we could remove more docs about
  `armeabi`.

I also fixed some tiny typos I found :)