### PR TITLE
e.g. usage and extra word removed

### DIFF
--- a/docs/xamarin-forms/user-interface/colors.md
+++ b/docs/xamarin-forms/user-interface/colors.md
@@ -20,7 +20,7 @@ This article introduces the various ways the `Color` class can be used in Xamari
 The `Color` class provides a number of methods to build a color instance
 
 -  **Named Colors** - a collection of common named-colors, including `Red`, `Green`, and `Blue`.
--  **FromHex** - string value similar to the syntax used in HTML, eg "00FF00". Alpha is can optionally be specified as the first pair of characters ("CC00FF00").
+-  **FromHex** - string value similar to the syntax used in HTML, for example "00FF00". Alpha can optionally be specified as the first pair of characters ("CC00FF00").
 -  **FromHsla** - Hue, saturation and luminosity  `double` values, with optional alpha value (0.0-1.0).
 -  **FromRgb** - Red, green, and blue `int` values (0-255).
 -  **FromRgba** - Red, green, blue, and alpha  `int` values (0-255).


### PR DESCRIPTION
I was checking the [guidelines](https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/e/eg) for spelling _eg_ and saw that it shouldn't be used. Also, there was an extra word in the next sentence, so I removed it.

Small things but they caught my eye so decided to go ahead with the pull request. However, I'd like to know if it would be preferable to gather more of these into a larger pull request over a longer period of time, instead of drip feeding them to you as I find them.