### PR TITLE
Dead sample links fixed

### DIFF
--- a/docs/android/app-fundamentals/android-audio.md
+++ b/docs/android/app-fundamentals/android-audio.md
@@ -567,7 +567,7 @@ which interface directly with memory buffers.
 
 ## Related Links
 
-- [Working With Audio (sample)](https://developer.xamarin.com/samples/Example_WorkingWithAudio/)
+- [Working With Audio (sample)](https://developer.xamarin.com/samples/monodroid/Example_WorkingWithAudio/)
 - [Media Player](https://developer.xamarin.com/api/type/Android.Media.MediaPlayer/)
 - [Media Recorder](https://developer.xamarin.com/api/type/Android.Media.MediaRecorder/)
 - [Audio Manager](https://developer.xamarin.com/api/type/Android.Media.AudioManager/)

--- a/docs/android/deploy-test/building-apps/abi-specific-apks.md
+++ b/docs/android/deploy-test/building-apps/abi-specific-apks.md
@@ -272,6 +272,6 @@ that has it's build scripted using Rake.
 
 ## Related Links
 
-- [OneABIPerAPK (sample)](https://developer.xamarin.com/samples/OneABIPerAPK/)
+- [OneABIPerAPK (sample)](https://developer.xamarin.com/samples/monodroid/OneABIPerAPK/)
 - [Publishing an Application](~/android/deploy-test/publishing/index.md)
 - [Multiple APK Support for Google Play](https://developer.android.com/google/play/publishing/multiple-apks.html)

--- a/docs/android/deploy-test/linker.md
+++ b/docs/android/deploy-test/linker.md
@@ -17,7 +17,7 @@ and which members are actually used. The linker then behaves like a *garbage col
 are referenced until the entire closure of referenced assemblies, types, and
 members is found. Then everything outside of this closure is *discarded*.
 
-For example, the [Hello, Android](https://developer.xamarin.com/samples/HelloM4A/) sample:
+For example, the [Hello, Android](https://developer.xamarin.com/samples/monodroid/HelloM4A/) sample:
 
 |Configuration|1.2.0 Size|4.0.1 Size|
 |---|---|---|

--- a/docs/android/platform/kitkat.md
+++ b/docs/android/platform/kitkat.md
@@ -1023,6 +1023,6 @@ KitKat API changes and additions.
 
 ## Related Links
 
-- [KitKat Sample](https://developer.xamarin.com/samples/KitKat/)
+- [KitKat Sample](https://developer.xamarin.com/samples/monodroid/KitKat/)
 - [Android 4.4 APIs](https://developer.android.com/about/versions/android-4.4.html)
 - [Android KitKat](https://developer.android.com/about/versions/kitkat.html)

--- a/docs/android/platform/maps-and-location/location.md
+++ b/docs/android/platform/maps-and-location/location.md
@@ -450,8 +450,8 @@ Services API.
 
 ## Related Links
 
-- [Location (sample)](https://developer.xamarin.com/samples/Location/)
-- [FusedLocationProvider (sample)](https://developer.xamarin.com/samples/FusedLocationProvider/)
+- [Location (sample)](https://developer.xamarin.com/samples/monodroid/Location/)
+- [FusedLocationProvider (sample)](https://developer.xamarin.com/samples/monodroid/FusedLocationProvider/)
 - [Google Play Services](https://developer.android.com/google/play-services/index.html)
 - [Criteria Class](https://developer.xamarin.com/api/type/Android.Locations.Criteria/)
 - [LocationManager Class](https://developer.xamarin.com/api/type/Android.Locations.LocationManager/)

--- a/docs/android/user-interface/controls/calendar.md
+++ b/docs/android/user-interface/controls/calendar.md
@@ -359,6 +359,6 @@ calendar capabilities.
 
 ## Related Links
 
-- [Calendar Demo (sample)](https://developer.xamarin.com/samples/CalendarDemo/)
+- [Calendar Demo (sample)](https://developer.xamarin.com/samples/monodroid/CalendarDemo/)
 - [Introducing Ice Cream Sandwich](http://www.android.com/about/ice-cream-sandwich/)
 - [Android 4.0 Platform](https://developer.android.com/sdk/android-4.0.html)

--- a/docs/android/user-interface/layouts/list-view/cursor-adapters.md
+++ b/docs/android/user-interface/layouts/list-view/cursor-adapters.md
@@ -234,5 +234,5 @@ described previously.
 
 ## Related Links
 
-- [SimpleCursorTableAdapter (sample)](https://developer.xamarin.com/samples/SimpleCursorTableAdapter/)
-- [CursorTableAdapter (sample)](https://developer.xamarin.com/samples/CursorTableAdapter/)
+- [SimpleCursorTableAdapter (sample)](https://developer.xamarin.com/samples/monodroid/SimpleCursorTableAdapter/)
+- [CursorTableAdapter (sample)](https://developer.xamarin.com/samples/monodroid/CursorTableAdapter/)

--- a/docs/android/user-interface/layouts/list-view/customizing-appearance.md
+++ b/docs/android/user-interface/layouts/list-view/customizing-appearance.md
@@ -500,6 +500,6 @@ through a list with custom row background colors.
 
 ## Related Links
 
-- [BuiltInViews (sample)](https://developer.xamarin.com/samples/BuiltInViews/)
-- [AccessoryViews (sample)](https://developer.xamarin.com/samples/AccessoryViews/)
-- [CustomRowView (sample)](https://developer.xamarin.com/samples/CustomRowView/)
+- [BuiltInViews (sample)](https://developer.xamarin.com/samples/monodroid/BuiltInViews/)
+- [AccessoryViews (sample)](https://developer.xamarin.com/samples/monodroid/AccessoryViews/)
+- [CustomRowView (sample)](https://developer.xamarin.com/samples/monodroid/CustomRowView/)

--- a/docs/android/wear/get-started/installation.md
+++ b/docs/android/wear/get-started/installation.md
@@ -142,4 +142,4 @@ To learn more about packaging Wear apps, see
 
 ## Related Links
 
-- [SkeletonWear (sample)](https://developer.xamarin.com/samples/SkeletonWear/)
+- [SkeletonWear (sample)](https://developer.xamarin.com/samples/monodroid/wear/SkeletonWear/)

--- a/docs/android/wear/screen-sizes.md
+++ b/docs/android/wear/screen-sizes.md
@@ -28,7 +28,7 @@ shouldn't be added as children of the controls described below.
 ### WatchViewStub
 
 See the
-[WatchViewStub](https://developer.xamarin.com/samples/WatchViewStub/) sample to see how to detect
+[WatchViewStub](https://developer.xamarin.com/samples/monodroid/wear/WatchViewStub/) sample to see how to detect
 screen type and display a different layout for each type.
 
 The main layout file contains a

--- a/docs/cross-platform/macios/binding/objective-c-libraries.md
+++ b/docs/cross-platform/macios/binding/objective-c-libraries.md
@@ -1858,4 +1858,4 @@ automatically.
 
 ## Related links
 
-- [Binding Sample](https://developer.xamarin.com/samples/BindingSample/)
+- [Binding Sample](https://developer.xamarin.com/samples/monotouch/BindingSample/)

--- a/docs/graphics-games/cocossharp/content-pipeline/walkthrough.md
+++ b/docs/graphics-games/cocossharp/content-pipeline/walkthrough.md
@@ -238,5 +238,5 @@ This walkthrough showed how to use the MonoGame Pipeline Tool to create .xnb fil
 
 - [MonoGame Downloads](http://www.monogame.net/downloads/)
 - [MonoGame Pipeline Documentation](http://www.monogame.net/documentation/?page=Pipeline)
-- [Starting BouncingGame Project for Android (sample)](https://developer.xamarin.com/samples/BouncingGameCompleteAndroid/)
+- [Starting BouncingGame Project for Android (sample)](https://developer.xamarin.com/samples/monodroid/BouncingGameCompleteAndroid/)
 - [ball.png Graphic (sample)](https://github.com/xamarin/mobile-samples/blob/master/BouncingGame/Resources/ball.png?raw=true)

--- a/docs/ios/app-fundamentals/delegates-protocols-and-events.md
+++ b/docs/ios/app-fundamentals/delegates-protocols-and-events.md
@@ -534,7 +534,7 @@ methods.
 
 ## Related Links
 
-- [Protocols, Delegates, and Events (sample)](https://developer.xamarin.com/samples/Protocols_Delegates_Events/)
+- [Protocols, Delegates, and Events (sample)](https://developer.xamarin.com/samples/monotouch/Protocols_Delegates_Events/)
 - [Hello, iOS](~/ios/get-started/hello-ios/index.md)
 - [Binding Objective-C Types](~/ios/platform/binding-objective-c/index.md)
 - [The Objective-C Programming Language](https://developer.apple.com/library/ios/#documentation/Cocoa/Conceptual/ObjectiveC/Introduction/introObjectiveC.html)

--- a/docs/ios/app-fundamentals/file-system.md
+++ b/docs/ios/app-fundamentals/file-system.md
@@ -10,7 +10,7 @@ ms.date: 11/12/2018
 ---
 # File system access in Xamarin.iOS
 
-[![Download Sample](~/media/shared/download.png) Download the sample](https://developer.xamarin.com/samples/FileSystemSampleCode/)
+[![Download Sample](~/media/shared/download.png) Download the sample](https://developer.xamarin.com/samples/monotouch/FileSystemSampleCode/)
 
 You can use Xamarin.iOS and the `System.IO` classes in the *.NET Base Class Library (BCL)* to access the iOS file system. The `File` class lets you create, delete, and read files, and the `Directory` class allows you to create, delete, or enumerate the
 contents of directories. You can also use `Stream` subclasses, which
@@ -448,6 +448,6 @@ application upgrades and backups.
 
 ## Related links
 
-- [FileSystem sample code](https://developer.xamarin.com/samples/FileSystemSampleCode/)
+- [FileSystem sample code](https://developer.xamarin.com/samples/monotouch/FileSystemSampleCode/)
 - [File System Programming Guide](https://developer.apple.com/library/ios/#documentation/FileManagement/Conceptual/FileSystemProgrammingGUide/Introduction/Introduction.html)
 - [Registering the File Types your App Supports](https://developer.apple.com/library/ios/#documentation/FileManagement/Conceptual/DocumentInteraction_TopicsForIOS/Articles/RegisteringtheFileTypesYourAppSupports.html#/apple_ref/doc/uid/TP40010411-SW1)

--- a/docs/ios/app-fundamentals/images-icons/app-icons.md
+++ b/docs/ios/app-fundamentals/images-icons/app-icons.md
@@ -205,6 +205,6 @@ To specify the iTunes Artwork, do the following:
 
 ## Related Links
 
-- [Working with Images (sample)](https://developer.xamarin.com/samples/WorkingWithImages/)
+- [Working with Images (sample)](https://developer.xamarin.com/samples/monotouch/WorkingWithImages/)
 - [Hello, iPhone](~/ios/get-started/hello-ios/index.md)
 - [Custom Icon and Image Creation Guidelines](https://developer.apple.com/library/ios/#documentation/UserExperience/Conceptual/MobileHIG/IconsImages/IconsImages.html))

--- a/docs/ios/app-fundamentals/images-icons/custom-document-types.md
+++ b/docs/ios/app-fundamentals/images-icons/custom-document-types.md
@@ -46,6 +46,6 @@ For more information about document types, see Apple’s [Uniform Type Identifie
 
 ## Related Links
 
-- [Working with Images (sample)](https://developer.xamarin.com/samples/WorkingWithImages/)
+- [Working with Images (sample)](https://developer.xamarin.com/samples/monotouch/WorkingWithImages/)
 - [Hello, iPhone](~/ios/get-started/hello-ios/index.md)
 - [Custom Icon and Image Creation Guidelines](https://developer.apple.com/library/ios/#documentation/UserExperience/Conceptual/MobileHIG/IconsImages/IconsImages.html)

--- a/docs/ios/app-fundamentals/images-icons/displaying-an-image.md
+++ b/docs/ios/app-fundamentals/images-icons/displaying-an-image.md
@@ -283,6 +283,6 @@ This code creates a new `UIImageView` and gives it an initial size and position.
 
 ## Related links
 
-- [Working with Images (sample)](https://developer.xamarin.com/samples/WorkingWithImages/)
+- [Working with Images (sample)](https://developer.xamarin.com/samples/monotouch/WorkingWithImages/)
 - [Hello, iPhone](~/ios/get-started/hello-ios/index.md)
 - [Image Size and Resolution (Apple)](https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/image-size-and-resolution/)

--- a/docs/ios/app-fundamentals/images-icons/index.md
+++ b/docs/ios/app-fundamentals/images-icons/index.md
@@ -59,6 +59,6 @@ This article covers including and managing an image asset in a Xamarin.iOS app t
 
 ## Related Links
 
-- [Working with Images (sample)](https://developer.xamarin.com/samples/WorkingWithImages/)
+- [Working with Images (sample)](https://developer.xamarin.com/samples/monotouch/WorkingWithImages/)
 - [Hello, iPhone](~/ios/get-started/hello-ios/index.md)
 - [Custom Icon and Image Creation Guidelines](https://developer.apple.com/library/ios/#documentation/UserExperience/Conceptual/MobileHIG/IconsImages/IconsImages.html)

--- a/docs/ios/platform/graphics-animation-ios/introduction-to-coreimage.md
+++ b/docs/ios/platform/graphics-animation-ios/introduction-to-coreimage.md
@@ -252,7 +252,7 @@ of different image filters available in the framework for you to use.
 
 ## Related Links
 
-- [Core Image (sample)](https://developer.xamarin.com/samples/CoreImage/)
+- [Core Image (sample)](https://developer.xamarin.com/samples/monotouch/CoreImage/)
 - [Adjust Contract and Brightness of an Image Recipe](https://github.com/xamarin/recipes/tree/master/Recipes/ios/media/coreimage/adjust_contrast_and_brightness_of_an_image)
 - [Using Core Image Filters](https://developer.apple.com/library/prerelease/ios/#documentation/GraphicsImaging/Conceptual/CoreImaging/ci_tasks/ci_tasks.html)
 - [CIFilter Class Reference](https://developer.apple.com/library/prerelease/ios/#documentation/GraphicsImaging/Reference/QuartzCoreFramework/Classes/CIFilter_Class/Reference/Reference.htm)

--- a/docs/ios/platform/introduction-to-ios6/changes-to-storekit.md
+++ b/docs/ios/platform/introduction-to-ios6/changes-to-storekit.md
@@ -668,7 +668,7 @@ functionality.
 
 ## Related Links
 
-- [StoreKit (sample)](https://developer.xamarin.com/samples/StoreKit/)
+- [StoreKit (sample)](https://developer.xamarin.com/samples/monotouch/StoreKit/)
 - [In-App Purchasing](~/ios/platform/in-app-purchasing/index.md)
 - [StoreKit Framework Reference](https://developer.apple.com/library/prerelease/ios/#documentation/StoreKit/Reference/StoreKit_Collection/_index.html)
 - [SKStoreProductViewController Class Reference](https://developer.apple.com/library/ios/documentation/StoreKit/Reference/SKITunesProductViewController_Ref/SKStoreProductViewController.html)

--- a/docs/ios/platform/social-framework.md
+++ b/docs/ios/platform/social-framework.md
@@ -504,5 +504,5 @@ is used to call each social network’s API.
 
 ## Related Links
 
-- [SocialFrameworkDemo (sample)](https://developer.xamarin.com/samples/SocialFrameworkDemo/)
+- [SocialFrameworkDemo (sample)](https://developer.xamarin.com/samples/monotouch/SocialFrameworkDemo/)
 - [Introduction to Web Services](~/cross-platform/data-cloud/web-services/index.md)

--- a/docs/ios/user-interface/controls/alerts.md
+++ b/docs/ios/user-interface/controls/alerts.md
@@ -106,5 +106,5 @@ actionSheetButton.TouchUpInside += ((sender, e) => {
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)
 - [Alert Controller](https://github.com/xamarin/recipes/tree/master/Recipes/ios/standard_controls/alertcontroller)

--- a/docs/ios/user-interface/controls/image.md
+++ b/docs/ios/user-interface/controls/image.md
@@ -78,4 +78,4 @@ Resource file references never need to include the **Resources** folder.
 
 ## Related links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)

--- a/docs/ios/user-interface/controls/index.md
+++ b/docs/ios/user-interface/controls/index.md
@@ -83,4 +83,4 @@ In this article, we will explore each of the three Web Views provided by Apple: 
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)

--- a/docs/ios/user-interface/controls/slider-switch-segmented-controls.md
+++ b/docs/ios/user-interface/controls/slider-switch-segmented-controls.md
@@ -100,5 +100,5 @@ It should be noted that the Segmented Control Style has been deprecated in iOS7,
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)
 - [Alert Controller](https://github.com/xamarin/recipes/tree/master/Recipes/ios/standard_controls/alertcontroller)

--- a/docs/ios/user-interface/controls/text-input.md
+++ b/docs/ios/user-interface/controls/text-input.md
@@ -92,4 +92,4 @@ textview1.DataDetectorTypes = UIDataDetectorType.PhoneNumber | UIDataDetectorTyp
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)

--- a/docs/ios/user-interface/controls/uicollectionview.md
+++ b/docs/ios/user-interface/controls/uicollectionview.md
@@ -1380,6 +1380,6 @@ affects a custom collection view layout.
 
 - [iOS 9 Samples](https://developer.xamarin.com/samples/ios/iOS9/)
 - [Collection View Sample](https://developer.xamarin.com/samples/monotouch/ios9/CollectionView/)
-- [SimpleCollectionView (sample)](https://developer.xamarin.com/samples/SimpleCollectionView/)
+- [SimpleCollectionView (sample)](https://developer.xamarin.com/samples/monotouch/SimpleCollectionView/)
 - [Events, Protocols and Delegates](~/ios/app-fundamentals/delegates-protocols-and-events.md)
 - [Working with Tables and Cells](~/ios/user-interface/controls/tables/index.md)

--- a/docs/ios/user-interface/ios-ui/creating-ui-objects.md
+++ b/docs/ios/user-interface/ios-ui/creating-ui-objects.md
@@ -182,4 +182,4 @@ When user interface objects are added programmatically to a `View` or `ViewContr
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)

--- a/docs/ios/user-interface/ios-ui/layout-options.md
+++ b/docs/ios/user-interface/ios-ui/layout-options.md
@@ -78,4 +78,4 @@ the image in view when the screen is rotated. Complex layouts typically require 
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)

--- a/docs/ios/user-interface/ios-ui/ui-thread.md
+++ b/docs/ios/user-interface/ios-ui/ui-thread.md
@@ -91,5 +91,5 @@ If an async method is called from a background thread (not the main UI thread) t
 
 ## Related Links
 
-- [Controls (sample)](https://developer.xamarin.com/samples/Controls/)
+- [Controls (sample)](https://developer.xamarin.com/samples/monotouch/Controls/)
 - [Threading](~/ios/app-fundamentals/threading.md)

--- a/docs/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md
+++ b/docs/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md
@@ -182,9 +182,7 @@ screens. In addition, it showed how to use MT.D in conjunction with a `UINavigat
 
 ## Related links
 
-- [MTDWalkthrough (sample)](https://developer.xamarin.com/samples/MTDWalkthrough/)
-- [Screencast - Miguel de Icaza creates an iOS login screen with MonoTouch.Dialog](http://youtu.be/3butqB1EG0c)
-- [Screencast - Easily create iOS user interfaces with MonoTouch.Dialog](http://youtu.be/j7OC5r8ZkYg)
+- [MTDWalkthrough (sample)](https://developer.xamarin.com/samples/monotouch/MTDWalkthrough/)
 - [Introduction to MonoTouch.Dialog](~/ios/user-interface/monotouch.dialog/index.md)
 - [Reflection API Walkthrough](~/ios/user-interface/monotouch.dialog/reflection-api-walkthrough.md)
 - [JSON Element Walkthrough](~/ios/user-interface/monotouch.dialog/json-element-walkthrough.md)

--- a/docs/ios/user-interface/monotouch.dialog/index.md
+++ b/docs/ios/user-interface/monotouch.dialog/index.md
@@ -743,8 +743,6 @@ allows creating elements dynamically from JSON.
 
 ## Related Links
 
-- [Screencast - Miguel de Icaza creates an iOS login screen with MonoTouch.Dialog](http://youtu.be/3butqB1EG0c)
-- [Screencast - Easily create iOS user interfaces with MonoTouch.Dialog](http://youtu.be/j7OC5r8ZkYg)
 - [Walkthrough: Creating an application using the Elements API](~/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md)
 - [Walkthrough: Creating an application using the Reflection API](~/ios/user-interface/monotouch.dialog/reflection-api-walkthrough.md)
 - [Walkthrough: Using a JSON Element to create a User Interface](~/ios/user-interface/monotouch.dialog/json-element-walkthrough.md)

--- a/docs/ios/user-interface/monotouch.dialog/json-element-walkthrough.md
+++ b/docs/ios/user-interface/monotouch.dialog/json-element-walkthrough.md
@@ -198,9 +198,7 @@ runtime.
 
 ## Related links
 
-- [MTDJsonDemo (sample)](https://developer.xamarin.com/samples/MTDJsonDemo/)
-- [Screencast - Miguel de Icaza creates an iOS login screen with MonoTouch.Dialog](http://youtu.be/3butqB1EG0c)
-- [Screencast - Easily create iOS user interfaces with MonoTouch.Dialog](http://youtu.be/j7OC5r8ZkYg)
+- [MTDJsonDemo (sample)](https://developer.xamarin.com/samples/monotouch/MTDJsonDemo/)
 - [Introduction to MonoTouch.Dialog](~/ios/user-interface/monotouch.dialog/index.md)
 - [Elements API Walkthrough](~/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md)
 - [Reflection API Walkthrough](~/ios/user-interface/monotouch.dialog/reflection-api-walkthrough.md)

--- a/docs/ios/user-interface/monotouch.dialog/reflection-api-walkthrough.md
+++ b/docs/ios/user-interface/monotouch.dialog/reflection-api-walkthrough.md
@@ -178,9 +178,7 @@ hierarchy that is created, as well as how to use MT.D with a `UINavigationContro
 
 ## Related links
 
-- [MTDReflectionWalkthrough (sample)](https://developer.xamarin.com/samples/MTDReflectionWalkthrough/)
-- [Screencast - Miguel de Icaza creates an iOS login screen with MonoTouch.Dialog](http://youtu.be/3butqB1EG0c)
-- [Screencast - Easily create iOS user interfaces with MonoTouch.Dialog](http://youtu.be/j7OC5r8ZkYg)
+- [MTDReflectionWalkthrough (sample)](https://developer.xamarin.com/samples/monotouch/MTDReflectionWalkthrough/)
 - [Introduction to MonoTouch Dialog](~/ios/user-interface/monotouch.dialog/index.md)
 - [Elements API Walkthrough](~/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md)
 - [JSON Element Walkthrough](~/ios/user-interface/monotouch.dialog/monotouch.dialog-json-markup.md)

--- a/docs/xamarin-forms/xaml/index.md
+++ b/docs/xamarin-forms/xaml/index.md
@@ -29,7 +29,7 @@ XAML allows developers to define user interfaces in Xamarin.Forms applications u
 
 ## [XAML Compilation](xamlc.md)
 
-XAML can be optionally compiled directly into intermediate language (IL) with the XAML compiler (XAMLC). This articles describes how to use XAMLC, and its benefits.
+XAML can be optionally compiled directly into intermediate language (IL) with the XAML compiler (XAMLC). This article describes how to use XAMLC, and its benefits.
 
 ## [XAML Previewer](xaml-previewer/index.md)
 


### PR DESCRIPTION
I continued the work that I started on #1757 and I'm pretty sure that after this all the sample links pointing to [developer.xamarin.com/samples](developer.xamarin.com/samples) work again.

Also, there were some links to Miguel de Icaza's Youtube screencasts that don't exist anymore and it looks like they haven't even been migrated anywhere else. That's why I simply removed them from the articles. MonoTouch.dialog section is probably one of the oldest in the whole documentation so some other surprises might also lurk there.

Lastly, there's a small typo fix that I stumbled upon.