### PR TITLE
Update Geolocation docs

### DIFF
--- a/docs/essentials/geolocation.md
+++ b/docs/essentials/geolocation.md
@@ -74,7 +74,7 @@ using Xamarin.Essentials;
 
 The Geolocation API will also prompt the user for permissions when necessary.
 
-You can get the last known [location](xref:Xamarin.Essentials.Location) of the device by calling the `GetLastKnownLocationAsync` method. This is often faster then doing a full query, but can be less accurate and may return `null`.
+You can get the last known [location](xref:Xamarin.Essentials.Location) of the device by calling the `GetLastKnownLocationAsync` method. This is often faster then doing a full query, but can be less accurate and may return `null` if no cached location exists.
 
 ```csharp
 try

--- a/docs/essentials/geolocation.md
+++ b/docs/essentials/geolocation.md
@@ -74,7 +74,7 @@ using Xamarin.Essentials;
 
 The Geolocation API will also prompt the user for permissions when necessary.
 
-You can get the last known [location](xref:Xamarin.Essentials.Location) of the device by calling the `GetLastKnownLocationAsync` method. This is often faster then doing a full query, but can be less accurate.
+You can get the last known [location](xref:Xamarin.Essentials.Location) of the device by calling the `GetLastKnownLocationAsync` method. This is often faster then doing a full query, but can be less accurate and may return `null`.
 
 ```csharp
 try


### PR DESCRIPTION
Noticed that GetLastKnownLocationAsync can return null, so made the docs a bit clearer about this.

Confirmed this is the case as james mentioned here: https://github.com/xamarin/Essentials/issues/519