### PR TITLE
Fixed a dead link

### DIFF
--- a/docs/ios/watchos/user-interface/image.md
+++ b/docs/ios/watchos/user-interface/image.md
@@ -168,4 +168,4 @@ The cache about 20 MB in size. It is kept across app restarts,
 ## Related Links
 
 - [WatchKitCatalog (sample)](https://developer.xamarin.com/samples/monotouch/watchOS/WatchKitCatalog/)
-- [Apple's Image doc](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/WatchKitProgrammingGuide/Images.html)
+- [Apple's Image doc](https://developer.apple.com/documentation/watchkit/wkinterfaceimage)


### PR DESCRIPTION
The original link was pointing to a part of the documentation that doesn't exist anymore. Looking at how this was fixed with the Table article, pointing to the WKInterfaceImage article seemed like the most viable option.