### PR TITLE
C# 6 changes

### DIFF
--- a/docs/cross-platform/platform/csharp-six.md
+++ b/docs/cross-platform/platform/csharp-six.md
@@ -14,7 +14,7 @@ ms.date: 03/22/2017
 _The version 6 of the C# language continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful._
 
 > [!NOTE]
-> For information about the latest version of the C# language – version 7 – refer to the article [What's New in C# 7.0](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7)
+> For information about the latest version of the C# language – version 7 – refer to the article [What's New in C# 7.0](/dotnet/csharp/whats-new/csharp-7)
 
 This document introduces the new features of C# 6. It is fully supported by the
 mono compiler and developers can start using the new features across all the

--- a/docs/cross-platform/platform/csharp-six.md
+++ b/docs/cross-platform/platform/csharp-six.md
@@ -1,6 +1,6 @@
 ---
 title: "C# 6 New Features Overview"
-description: "The version 6 of the C# language continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful."
+description: "Version 6 of the C# language continues to evolve the language to have less boilerplate code, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful."
 ms.prod: xamarin
 ms.assetid: 4B4E41A8-68BA-4E2B-9539-881AC19971B
 ms.custom: xamu-video

--- a/docs/cross-platform/platform/csharp-six.md
+++ b/docs/cross-platform/platform/csharp-six.md
@@ -1,6 +1,6 @@
 ---
 title: "C# 6 New Features Overview"
-description: "The latest version of the C# language – version 6 – continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful."
+description: "The version 6 of the C# language continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful."
 ms.prod: xamarin
 ms.assetid: 4B4E41A8-68BA-4E2B-9539-881AC19971B
 ms.custom: xamu-video
@@ -11,7 +11,10 @@ ms.date: 03/22/2017
 
 # C# 6 New Features Overview
 
-_The latest version of the C# language – version 6 – continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful._
+_The version 6 of the C# language continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful._
+
+> [!NOTE]
+> For information about the latest version of the C# language – version 7 – refer to the article [What's New in C# 7.0](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7)
 
 This document introduces the new features of C# 6. It is fully supported by the
 mono compiler and developers can start using the new features across all the

--- a/docs/cross-platform/platform/csharp-six.md
+++ b/docs/cross-platform/platform/csharp-six.md
@@ -11,7 +11,7 @@ ms.date: 03/22/2017
 
 # C# 6 New Features Overview
 
-_The version 6 of the C# language continues to evolve the language to have less boilerplate, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful._
+_Version 6 of the C# language continues to evolve the language to have less boilerplate code, improved clarity, and more consistency. Cleaner initialization syntax, the ability to use await in catch/finally blocks, and the null-conditional ? operator are especially useful._
 
 > [!NOTE]
 > For information about the latest version of the C# language – version 7 – refer to the article [What's New in C# 7.0](/dotnet/csharp/whats-new/csharp-7)


### PR DESCRIPTION
Since C# 6 is not the latest version anymore, I made some wording changes to signify that. I thought about linking to the C# 8 article but since there's no stable release yet, I thought that C# 7 is more correct.

Another change is the addition of a Note block that leads the users to information about the latest version of C#, since there's no dedicated article for that in the Xamarin docs (probably doesn't even make sense because it would just be a summary/duplication of existing articles in the dotnet docs).