### PR TITLE
Remove extra space in code block

### DIFF
--- a/docs/essentials/connectivity.md
+++ b/docs/essentials/connectivity.md
@@ -96,7 +96,7 @@ public class ConnectivityTest
         Connectivity.ConnectivityChanged += Connectivity_ConnectivityChanged;
     }
 
-    void Connectivity_ConnectivityChanged(object sender, ConnectivityChangedEventArgs  e)
+    void Connectivity_ConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
     {
         var access = e.NetworkAccess;
         var profiles = e.ConnectionProfiles;


### PR DESCRIPTION
Fairly certain this is just a typo and not a code whitespace style choice of any kind.