### PR TITLE
Xamarin University link broken

### DIFF
--- a/docs/cross-platform/macios/unified/updating-ios-apps.md
+++ b/docs/cross-platform/macios/unified/updating-ios-apps.md
@@ -110,4 +110,3 @@ Whether or not you choose to use the automatic or manual method to convert your 
 - [Tips for Updating Code to the Unified API](~/cross-platform/macios/unified/updating-tips.md)
 - [Working with Native Types in Cross-Platform Apps](~/cross-platform/macios/native-types-cross-platform.md)
 - [Classic vs Unified API differences](https://developer.xamarin.com/releases/ios/api_changes/classic-vs-unified-8.6.0/)
-- [Migrating to the Unified API (video)](http://university.xamarin.com/lightninglectures/migrating-to-the-unified-api)


### PR DESCRIPTION
The video link to Xamarin University was broken and the content doesn't seem to be available anymore. Removed the link from the **Related Links** section.