### PR TITLE
Removed a dead link

### DIFF
--- a/docs/cross-platform/app-fundamentals/nuget-manual.md
+++ b/docs/cross-platform/app-fundamentals/nuget-manual.md
@@ -95,6 +95,5 @@ Some open-source examples that you can refer to:
 
 ## Related Links
 
-- [Nugetizer-3000 Automated Nuget Creation](~/cross-platform/app-fundamentals/nuget-multiplatform-libraries/index.md)
-- [Updating NuGets for iOS 64-bit](https://blog.xamarin.com/how-to-update-nuget-packages-for-64-bit/)
+- [Nugetizer-3000 Automated Nuget Creation](~/cross-platform/app-fundamentals/nuget-multiplatform-libraries/index.md)       
 - [Including a NuGet in your Project](https://docs.microsoft.com/visualstudio/mac/nuget-walkthrough)


### PR DESCRIPTION
**Updating NuGets for iOS 64-bit** article leads to a 404-page, and Matt Ward's blog articles haven't been transferred to Microsoft.com (as far as I can see), so I removed the link.

The closest article that could have relevant content would probably be this one: https://docs.microsoft.com/en-us/xamarin/cross-platform/macios/unified/updating-ios-apps