### PR TITLE
Updated an outdated anchor text

### DIFF
--- a/docs/mac/get-started/related.md
+++ b/docs/mac/get-started/related.md
@@ -11,7 +11,7 @@ ms.date: 12/02/2016
 
 # Xamarin.Mac – Related Documentation
 
-In addition to the Mac section of [developer.xamarin.com](~/mac/get-started/index.md) there are three great sources of documentation that can also be of assistance with Xamarin.Mac questions:
+In addition to the Mac section of [Microsoft Docs](~/mac/get-started/index.md) there are three great sources of documentation that can also be of assistance with Xamarin.Mac questions:
 
 - [**Xamarin.iOS documentation**](~/ios/get-started/index.md) - For many APIs (primarily outside of AppKit/UIKit) there are only small differences between the iOS and macOS versions. In some cases where a given iOS API has a name of `UIFoo`, a similar API named `NSFoo` can be found on macOS. These examples will be generally in C# already.
 


### PR DESCRIPTION
Changed developer.xamarin.com to Microsoft Docs. Also thought about docs.microsoft.com but I guess the official name fits better?