### PR TITLE
Menu item removed

### DIFF
--- a/docs/tools/TOC.yml
+++ b/docs/tools/TOC.yml
@@ -44,11 +44,6 @@
           href: workbooks/workbook.md
         - name: Editor Keyboard Shortcuts
           href: workbooks/keybindings.md
-        - name: Sample Workbooks
-          href: workbooks/samples/index.md
-          items: 
-            - name: TinyRenderer
-              href: workbooks/samples/tinyrenderer.md
         - name: Troubleshooting
           href: workbooks/troubleshooting/index.md
           items: 


### PR DESCRIPTION
Removed the menu item pointing to the samples page that doesn't exist anymore. The [Workbooks main page](https://docs.microsoft.com/en-us/xamarin/tools/workbooks/) links straight to the GitHub repository with samples so that should be enough.