### PR TITLE
Fix samples using incorrect variable name

### DIFF
--- a/docs/ios/app-fundamentals/ios-code-only.md
+++ b/docs/ios/app-fundamentals/ios-code-only.md
@@ -84,10 +84,10 @@ The steps below guide you through removing the Storyboard from an application:
     public override bool FinishedLaunching(UIApplication app, NSDictionary options)
     {
         // create a new window instance based on the screen size
-        window = new UIWindow(UIScreen.MainScreen.Bounds);
+        Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
         // make the window visible
-        window.MakeKeyAndVisible();
+        Window.MakeKeyAndVisible();
 
         return true;
     }
@@ -113,10 +113,10 @@ public class AppDelegate : UIApplicationDelegate
     public override bool FinishedLaunching(UIApplication app, NSDictionary options)
     {
         // create a new window instance based on the screen size
-        window = new UIWindow(UIScreen.MainScreen.Bounds);
+        Window = new UIWindow(UIScreen.MainScreen.Bounds);
 
         // make the window visible
-        window.MakeKeyAndVisible();
+        Window.MakeKeyAndVisible();
 
         return true;
     }
@@ -127,7 +127,7 @@ If you were to run this application now, you would likely get an exception throw
 
 ## Adding a controller
 
-Your app can contain many View Controllers, but it needs to have one Root View Controller to control all the View Controllers.  Add a controller to the window by creating a `UIViewController` instance and setting it to the `window.RootViewController` property:
+Your app can contain many View Controllers, but it needs to have one Root View Controller to control all the View Controllers.  Add a controller to the window by creating a `UIViewController` instance and setting it to the `Window.RootViewController` property:
 
 ```csharp
 public class AppDelegate : UIApplicationDelegate


### PR DESCRIPTION
Various samples were using variable `window` instead of `Window` which doesn't exist and causes errors if you try to compile that code.