### PR TITLE
Add clarification about using ViewCell

### DIFF
--- a/docs/xamarin-forms/user-interface/collectionview/populate-data.md
+++ b/docs/xamarin-forms/user-interface/collectionview/populate-data.md
@@ -237,7 +237,7 @@ The `MonkeyDataTemplateSelector` class defines `AmericanMonkey` and `OtherMonkey
 
 For more information about data template selectors, see [Create a Xamarin.Forms DataTemplateSelector](~/xamarin-forms/app-fundamentals/templates/data-templates/selector.md). 
 
-> [!NOTE>
+> [!IMPORTANT]
 > When using [`CollectionView`](xref:Xamarin.Forms.CollectionView), never set the root element of your [`DataTemplate`](xref:Xamarin.Forms.DataTemplate) objects to a `ViewCell`. This will result in an exception being thrown because `CollectionView` has no concept of cells.
 
 ## Related links

--- a/docs/xamarin-forms/user-interface/collectionview/populate-data.md
+++ b/docs/xamarin-forms/user-interface/collectionview/populate-data.md
@@ -235,7 +235,7 @@ The `MonkeyDataTemplateSelector` class defines `AmericanMonkey` and `OtherMonkey
 
 [![Screenshot of CollectionView runtime item template selection, on iOS and Android](populate-data-images/datatemplateselector.png "Runtime item template selection in a CollectionView")](populate-data-images/datatemplateselector-large.png#lightbox "Runtime item template selection in a CollectionView")
 
-For more information about data template selectors, see [Create a Xamarin.Forms DataTemplateSelector](~/xamarin-forms/app-fundamentals/templates/data-templates/selector.md).
+For more information about data template selectors, see [Create a Xamarin.Forms DataTemplateSelector](~/xamarin-forms/app-fundamentals/templates/data-templates/selector.md). **Important** Do not wrap the templates in a `ViewCell` as shown in the linked example - doing so will cause an exception at runtime. Use a layout control such as `StackLayout` instead.
 
 ## Related links
 

--- a/docs/xamarin-forms/user-interface/collectionview/populate-data.md
+++ b/docs/xamarin-forms/user-interface/collectionview/populate-data.md
@@ -235,7 +235,10 @@ The `MonkeyDataTemplateSelector` class defines `AmericanMonkey` and `OtherMonkey
 
 [![Screenshot of CollectionView runtime item template selection, on iOS and Android](populate-data-images/datatemplateselector.png "Runtime item template selection in a CollectionView")](populate-data-images/datatemplateselector-large.png#lightbox "Runtime item template selection in a CollectionView")
 
-For more information about data template selectors, see [Create a Xamarin.Forms DataTemplateSelector](~/xamarin-forms/app-fundamentals/templates/data-templates/selector.md). **Important** Do not wrap the templates in a `ViewCell` as shown in the linked example - doing so will cause an exception at runtime. Use a layout control such as `StackLayout` instead.
+For more information about data template selectors, see [Create a Xamarin.Forms DataTemplateSelector](~/xamarin-forms/app-fundamentals/templates/data-templates/selector.md). 
+
+> [!NOTE>
+> When using [`CollectionView`](xref:Xamarin.Forms.CollectionView), never set the root element of your [`DataTemplate`](xref:Xamarin.Forms.DataTemplate) objects to a `ViewCell`. This will result in an exception being thrown because `CollectionView` has no concept of cells.
 
 ## Related links
 


### PR DESCRIPTION
Using the ViewCell as shown in the DataTemplateSelector example will cause an exception at runtime. The exception is not very clear either, and it was only clear after some searching and reading the source code. The relevant sample XAML file in the linked sample shows the proper arrangement, but a reader is more likely to click the DataTemplateSelector link first.