### PR TITLE
Update cache data description

### DIFF
--- a/docs/essentials/file-system-helpers.md
+++ b/docs/essentials/file-system-helpers.md
@@ -23,7 +23,7 @@ Add a reference to Xamarin.Essentials in your class:
 using Xamarin.Essentials;
 ```
 
-To get the application's directory to store **cache data**. Cache data can be used for any data that needs to persist longer than temporary data, but should not be data that is required to properly operate.
+To get the application's directory to store **cache data**. Cache data can be used for any data that needs to persist longer than temporary data, but should not be data that is required to properly operate, as the OS dictates when this storage is cleared.
 
 ```csharp
 var cacheDir = FileSystem.CacheDirectory;


### PR DESCRIPTION
Fixes #1713 

Clearly state that cache data can be cleared by the OS, which is the main reason for stating _should not be data that is required to properly operate_.