### PR TITLE
Updated stack-layout.md

### DIFF
--- a/docs/xamarin-forms/user-interface/layouts/stack-layout.md
+++ b/docs/xamarin-forms/user-interface/layouts/stack-layout.md
@@ -214,7 +214,7 @@ The above code results in the following layout:
 
 ![](stack-layout-images/stack.png "Complex StackLayout")
 
-Notice that `StackLayouts`s are nested, because in some cases nesting layouts can be easier than presenting all elements within the same layout. Also notice that, because `StackLayout` doesn't support overlapping items, the page doesn't have some of the layout niceties found in the pages for the other layouts.
+Notice that the `StackLayouts` are nested, because in some cases nesting layouts can be easier than presenting all elements within the same layout. Also notice that, because `StackLayout` doesn't support overlapping items, the page doesn't have some of the layout niceties found in the pages for the other layouts.
 
 
 


### PR DESCRIPTION
Changed

Notice that `StackLayouts`s are nested, because in some cases nesting layouts can be easier than presenting all elements within the same layout. Also notice that, because `StackLayout` doesn't support overlapping items, the page doesn't have some of the layout niceties found in the pages for the other layouts.

to read

Notice that the `StackLayouts` are nested, because in some cases nesting layouts can be easier than presenting all elements within the same layout. Also notice that, because `StackLayout` doesn't support overlapping items, the page doesn't have some of the layout niceties found in the pages for the other layouts.

as I believe it reads better