### PR TITLE
fix:  MD020/no-missing-space-closed-atx

### DIFF
--- a/docs/cross-platform/platform/razor-html-templates/index.md
+++ b/docs/cross-platform/platform/razor-html-templates/index.md
@@ -162,7 +162,7 @@ and then set the client on the web view:
 webView.SetWebViewClient (new HybridWebViewClient ());
 ```
 
-### Calling JavaScript from C#
+### Calling JavaScript from C\#
 
 In addition to telling a web view to load a new HTML page, C# code can also run JavaScript within the currently displayed page. Entire JavaScript code blocks can be created using C# strings and executed, or you can craft method calls to JavaScript already available on the page via `script` tags.
 
@@ -461,7 +461,7 @@ var parameters = System.Web.HttpUtility.ParseQueryString(resources[1]);
 
 After handling the URL, the method aborts the navigation so that the web view does not attempt to finish navigating to the custom URL.
 
-#### Manipulating the template from C#
+#### Manipulating the template from C\#
 
 Communication to a rendered HTML web view from C# is done by calling JavaScript in the web view. On iOS, this is done by calling `EvaluateJavascript` on the UIWebView:
 

--- a/docs/graphics-games/urhosharp/fsharp.md
+++ b/docs/graphics-games/urhosharp/fsharp.md
@@ -8,7 +8,7 @@ ms.author: crdun
 ms.date: 03/29/2017
 ---
 
-# Programming UrhoSharp with F#
+# Programming UrhoSharp with F\#
 
 UrhoSharp can be programmed with F# using the same libraries and concepts used by C# programmers. The [Using UrhoSharp](~/graphics-games/urhosharp/using.md) article gives an overview of the UrhoSharp engine and should be read prior to this article.
 

--- a/docs/ios/user-interface/ios-ui/creating-ui-objects.md
+++ b/docs/ios/user-interface/ios-ui/creating-ui-objects.md
@@ -91,7 +91,7 @@ property that can be referenced in code:
 For more information on how Xcode's Interface Builder integrates with Visual Studio for Mac,
 refer to the [Xib Code Generation](~/ios/internals/xib-code-generation.md#generated) document.
 
-## Using C#
+## Using C\#
 
 If you decide to programmatically create a user interface object using C# (in a View or View Controller, for example),
 follow these steps:

--- a/docs/xamarin-forms/platform/native-views/code.md
+++ b/docs/xamarin-forms/platform/native-views/code.md
@@ -9,7 +9,7 @@ ms.author: dabritch
 ms.date: 04/27/2016
 ---
 
-# Native Views in C#
+# Native Views in C\#
 
 [![Download Sample](~/media/shared/download.png) Download the sample](https://docs.microsoft.com/samples/xamarin/xamarin-forms-samples/userinterface-nativeembedding)
 

--- a/docs/xamarin-forms/user-interface/styles/css/index.md
+++ b/docs/xamarin-forms/user-interface/styles/css/index.md
@@ -123,7 +123,7 @@ Alternatively, a style sheet can be loaded and parsed with the [`StyleSheet`](xr
 
 For more information about resource dictionaries, see [Resource Dictionaries](~/xamarin-forms/xaml/resource-dictionaries.md).
 
-### C#
+### C\#
 
 In C#, a style sheet can be loaded as an embedded resource and added to a [`ResourceDictionary`](xref:Xamarin.Forms.ResourceDictionary):
 


### PR DESCRIPTION

No space inside hashes on closed atx style heading.
Markdowing considers the closing # part of a closed_atx style heading.