### PR TITLE
fix: MD023/heading-start-left/header-start-left

### DIFF
--- a/docs/essentials/get-started.md
+++ b/docs/essentials/get-started.md
@@ -25,6 +25,7 @@ Xamarin.Essentials is available as a NuGet package that can be added to any exis
 
 3. Add the [**Xamarin.Essentials**](https://www.nuget.org/packages/Xamarin.Essentials/) NuGet package to each project:
 
+    <!--markdownlint-disable MD023 -->
     # [Visual Studio](#tab/windows)
 
     In the Solution Explorer panel, right click on the solution name and select **Manage NuGet Packages**. Search for **Xamarin.Essentials** and install the package into **ALL** projects including Android, iOS, UWP, and .NET Standard libraries.

--- a/docs/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md
+++ b/docs/ios/user-interface/monotouch.dialog/elements-api-walkthrough.md
@@ -20,9 +20,9 @@ will be added to the table for the task. Selecting the row will navigate to the
 detail screen that allows us to update the task description and the due date, as
 illustrated below:
 
- [![](elements-api-walkthrough-images/01-task-list-app.png "Selecting the row will navigate to the detail screen that allows us to update the task description and the due date")](elements-api-walkthrough-images/01-task-list-app.png#lightbox)
+[![](elements-api-walkthrough-images/01-task-list-app.png "Selecting the row will navigate to the detail screen that allows us to update the task description and the due date")](elements-api-walkthrough-images/01-task-list-app.png#lightbox)
 
- ## Setting up MT.D
+## Setting up MT.D
 
 MT.D is distributed with Xamarin.iOS. To use it, right-click on the
 **References** node of a Xamarin.iOS project in Visual Studio 2017 or


### PR DESCRIPTION

Headings must start at the beginning of the line.
The old Tab format isn't compatible with this rule so was inline-disable on one doc