### PR TITLE
fix: MD045/no-alt-text

### DIFF
--- a/docs/ios/deploy-test/app-distribution/ad-hoc-distribution.md
+++ b/docs/ios/deploy-test/app-distribution/ad-hoc-distribution.md
@@ -46,15 +46,15 @@ The next section will describe how to get set up with a Distribution Certificate
 3. Click the **+** button to create a new Certificate.
 4. Under the *Production* heading, select **In-House and Ad Hoc**, or **App Store and Ad Hoc**, depending on your program membership:
 
-   [![](ad-hoc-distribution-images/cert-first-small.png "Select In-House and Ad Hoc, or App Store and Ad Hoc")](ad-hoc-distribution-images/cert-first-large.png#lightbox)
+   [![Select In-House and Ad Hoc, or App Store and Ad Hoc](ad-hoc-distribution-images/cert-first-small.png)](ad-hoc-distribution-images/cert-first-large.png#lightbox)
 
 5. Click Continue, and follow the instructions to create a Certificate Signing Request via Keychain Access:
 
-   [![](ad-hoc-distribution-images/createcertmanually02.png "Create a Certificate Signing Request via Keychain Access")](ad-hoc-distribution-images/createcertmanually02.png#lightbox)
+   [![Create a Certificate Signing Request via Keychain Access](ad-hoc-distribution-images/createcertmanually02.png)](ad-hoc-distribution-images/createcertmanually02.png#lightbox)
 
 6. Once you have created the CSR as instructed, click Continue, and upload the CSR to the Member Center:
 
-   [![](ad-hoc-distribution-images/createcertmanually03.png "Upload the CSR to the Member Center")](ad-hoc-distribution-images/createcertmanually03.png#lightbox)
+   [![Upload the CSR to the Member Center](ad-hoc-distribution-images/createcertmanually03.png)](ad-hoc-distribution-images/createcertmanually03.png#lightbox)
 
 7. Click Generate to create a certificate.
 8. Finally, Download the completed certificate and double-click on the file to install it.
@@ -63,10 +63,10 @@ The next section will describe how to get set up with a Distribution Certificate
 Alternatively, it is possible to request a Certificate via the Preferences dialog in Xcode. To do this, follow the steps below:
 
 1. Select your team, and click **Manage Certificates…**:
-    [![](ad-hoc-distribution-images/selectteam.png "Selecting the team")](ad-hoc-distribution-images/selectteam.png#lightbox)
+    [![Selecting the team](ad-hoc-distribution-images/selectteam.png)](ad-hoc-distribution-images/selectteam.png#lightbox)
 
 2. Next, click the **plus (+)** button and select **iOS App Store**:
-    [![](ad-hoc-distribution-images/selectcert.png "Selecting iOS App Store")](ad-hoc-distribution-images/selectcert.png#lightbox)
+    [![Selecting iOS App Store](ad-hoc-distribution-images/selectcert.png)](ad-hoc-distribution-images/selectcert.png#lightbox)
 
 <a name="createprofile" />
 
@@ -89,23 +89,23 @@ As with any other Provisioning Profile you create, an App ID will be required to
 Once you have the required components needed for creating a Distribution Profile, follow the steps below to create it:
 
 1. Return to the Apple Provisioning Portal and select **Provisioning > Distribution**:
-    [![](ad-hoc-distribution-images/distribute01.png "Select Provisioning > Distribution")](ad-hoc-distribution-images/distribute01.png#lightbox)
+    [![Select Provisioning > Distribution](ad-hoc-distribution-images/distribute01.png)](ad-hoc-distribution-images/distribute01.png#lightbox)
 
 2. Click the **+** button and select the type of Distribution Profile that you want to create as **Ad-Hoc**:
 
-    [![](ad-hoc-distribution-images/distribute02.png "Create an Ad-Hoc Distribution type")](ad-hoc-distribution-images/distribute02.png#lightbox)
+    [![Create an Ad-Hoc Distribution type](ad-hoc-distribution-images/distribute02.png)](ad-hoc-distribution-images/distribute02.png#lightbox)
 
 3. Click the **Continue** button and select App ID from the dropdown list that you want to create a Distribution Profile for:
 
-    [![](ad-hoc-distribution-images/distribute03.png "Select App ID from the dropdown list")](ad-hoc-distribution-images/distribute03.png#lightbox)
+    [![Select App ID from the dropdown list](ad-hoc-distribution-images/distribute03.png)](ad-hoc-distribution-images/distribute03.png#lightbox)
 
 4. Click the **Continue** button and select distribution certificate required to sign the application:
 
-    [![](ad-hoc-distribution-images/distribute04.png "Select distribution certificate required to sign the application")](ad-hoc-distribution-images/distribute04.png#lightbox)
+    [![Select distribution certificate required to sign the application](ad-hoc-distribution-images/distribute04.png)](ad-hoc-distribution-images/distribute04.png#lightbox)
 
 5. Click the **Continue** button and enter a **Name** for the new Distribution Profile:
 
-    [![](ad-hoc-distribution-images/distribute06.png "Enter a Name for the new Distribution Profile")](ad-hoc-distribution-images/distribute06.png#lightbox)
+    [![Enter a Name for the new Distribution Profile](ad-hoc-distribution-images/distribute06.png)](ad-hoc-distribution-images/distribute06.png#lightbox)
 
 6. Click the **Generate** button to create the new profile and finalize the process.
 
@@ -132,13 +132,13 @@ When you are ready to do a final build of a Xamarin.iOS application, select the 
 1. Double-click the project name in the **Solution Explorer** to open it for edit.
 2. Select **iOS Bundle Signing** and the type of build from the **Configuration** dropdown:
 
-    ![](ad-hoc-distribution-images/releasexs01.png "Select the type of build from the Configuration dropdown")
+    ![Select the type of build from the Configuration dropdown](ad-hoc-distribution-images/releasexs01.png)
 3. In most cases, the **Signing Identity** and the **Provisioning Profile** can be left as a default values of **Automatic** and Visual Studio for Mac will choose the correct profile, based on the Bundle Identifier in the Info.plist:
 
-    ![](ad-hoc-distribution-images/releasexs02.png "The Signing Identity and the Provisioning Profile set to the default values of Automatic")
+    ![The Signing Identity and the Provisioning Profile set to the default values of Automatic](ad-hoc-distribution-images/releasexs02.png)
 4. If required, select the Signing Identity and Distribution Profile (the one created above) from the drop-downs:
 
-    ![](ad-hoc-distribution-images/releasexs03.png "Select the Signing Identity and Distribution Profile")
+    ![Select the Signing Identity and Distribution Profile](ad-hoc-distribution-images/releasexs03.png)
 5. Click the **OK** button to save the changes.
 
 # [Visual Studio](#tab/windows)
@@ -147,13 +147,13 @@ When you are ready to do a final build of a Xamarin.iOS application, select the 
 1. Right-click the project name in the **Solution Explorer** and select **Properties** to open it for edit.
 2. Select **iOS Bundle Signing** and the type of build from the **Configuration** dropdown:
 
-    ![](ad-hoc-distribution-images/releasevs01.png "Select the type of build from the Configuration dropdown")
+    ![Select the type of build from the Configuration dropdown](ad-hoc-distribution-images/releasevs01.png)
 3. In most cases, the **Signing Identity** and the **Provisioning Profile** can be left as a default values of **Automatic** and Visual Studio will choose the correct profile, based on the Bundle Identifier in the Info.plist:
 
-    ![](ad-hoc-distribution-images/releasevs02.png "The Signing Identity and the Provisioning Profile set to the default values of Automatic")
+    ![The Signing Identity and the Provisioning Profile set to the default values of Automatic](ad-hoc-distribution-images/releasevs02.png)
 4. If required, select the Signing Identity and Distribution Profile (the one created above) from the drop-downs:
 
-    ![](ad-hoc-distribution-images/releasevs03.png "Select the Signing Identity and Distribution Profile")
+    ![Select the Signing Identity and Distribution Profile](ad-hoc-distribution-images/releasevs03.png)
 5. Save the changes to the project's Properties.
 
 -----

--- a/docs/mac/platform/storyboards/indepth.md
+++ b/docs/mac/platform/storyboards/indepth.md
@@ -13,11 +13,11 @@ ms.date: 03/14/2017
 
 A storyboard defines all of the UI for a given app broken down into a functional overview of its view controllers. In Xcode's Interface Builder, each of these controllers lives in its own Scene.
 
-[![](indepth-images/intro01.png "A storyboard in Xcode's Interface Builder")](indepth-images/intro01.png#lightbox)
+[![A storyboard in Xcode's Interface Builder](indepth-images/intro01.png)](indepth-images/intro01.png#lightbox)
 
 The storyboard is a resource file (with the extensions of `.storyboard`) that gets included in the Xamarin.Mac app's bundle when it is compiled and shipped. To define the starting Storyboard for your app, edit it's `Info.plist` file and select the **Main Interface** from the dropdown box: 
 
-[![](indepth-images/sb01.png "The Info.plist editor")](indepth-images/sb01.png#lightbox)
+[![The Info.plist editor](indepth-images/sb01.png)](indepth-images/sb01.png#lightbox)
 
 <a name="Loading-from-Code" />
 
@@ -36,11 +36,11 @@ controller.ShowWindow(this);
 
 The `FromName` loads the Storyboard file with the given name that has been included in the app's bundle. The `InstantiateControllerWithIdentifier` creates an instance of the View Controller with the given Identity. You set the Identity in Xcode's Interface Builder when designing the UI:
 
-[![](indepth-images/sb02.png "Setting the Storyboard ID")](indepth-images/sb02.png#lightbox)
+[![Setting the Storyboard ID](indepth-images/sb02.png)](indepth-images/sb02.png#lightbox)
 
 Optionally, you can use the `InstantiateInitialController` method to load the View Controller that has been assigned the Initial Controller in Interface Builder:
 
-[![](indepth-images/sb03.png "Setting the initial controller")](indepth-images/sb03.png#lightbox)
+[![Setting the initial controller](indepth-images/sb03.png)](indepth-images/sb03.png#lightbox)
 
 It's marked by the **Storyboard Entry Point** and the open ended arrow above.
 
@@ -71,7 +71,7 @@ Several new methods have been added to the `NSViewController` class to support S
 
 Additionally, `NSViewControllers` are now part of the Window's _Responder Chain_:
 
-[![](indepth-images/vc01.png "The Responder Chain")](indepth-images/vc01.png#lightbox)
+[![The Responder Chain](indepth-images/vc01.png)](indepth-images/vc01.png#lightbox)
 
 And as such they are wired-up to receive and respond to events such as Cut, Copy and Paste menu item selections. This automatic View Controller wire-up only occurs on apps running on macOS Sierra (10.12) and greater.
 
@@ -81,13 +81,13 @@ And as such they are wired-up to receive and respond to events such as Cut, Copy
 
 In Storyboards, View Controllers (such as the Split View Controller and the Tab View Controller) can now implement _Containment_, such that they can "contain" other sub View Controllers:
 
-[![](indepth-images/vc02.png "An example of View Controller Containment")](indepth-images/vc02.png#lightbox)
+[![An example of View Controller Containment](indepth-images/vc02.png)](indepth-images/vc02.png#lightbox)
 
 Child View Controllers contain methods and properties to tie them back to their Parent View Controller and to work with displaying and removing Views from the screen.
 
 All Container View Controllers built into macOS have a specific layout which Apple suggest that you follow if creating your own custom Container View Controllers:
 
-[![](indepth-images/vc03.png "The View Controller layout")](indepth-images/vc03.png#lightbox)
+[![The View Controller layout](indepth-images/vc03.png)](indepth-images/vc03.png#lightbox)
 
 The Collection View Controller contains an array of Collection View Items, each of which contain one or more View Controllers that contain their own Views.
 
@@ -126,7 +126,7 @@ PerformSegue("MyNamedSegue", this);
 
 The Segue ID is defined inside of Xcode's Interface Builder when you are laying out the app's UI:
 
-[![](indepth-images/sg02.png "Entering a Segue Name")](indepth-images/sg02.png#lightbox)
+[![Entering a Segue Name](indepth-images/sg02.png)](indepth-images/sg02.png#lightbox)
 
 In the View Controller that is acting as the source of the Segue, you should override the `PrepareForSegue` method and do any initialization required before the Segue is executed and the specified View Controller is displayed:
 
@@ -210,7 +210,7 @@ A couple of things to note here:
 
 To use this new Segue type in Xcode's Interface Builder, we need to compile the app first, then switch to Xcode and add a new Segue between two scenes. Set the **Style** to **Custom** and the **Segue Class** to `ReplaceViewSegue` (the name of our custom Segue class):
 
-[![](indepth-images/sg01.png "Setting the Segue class")](indepth-images/sg01.png#lightbox)
+[![Setting the Segue class](indepth-images/sg01.png)](indepth-images/sg01.png#lightbox)
 
 <a name="Triggered-Segues" />
 
@@ -266,21 +266,21 @@ To add a reference to an external Storyboard, do the following:
 
 1. In the **Solution Explorer**, right-click on the Project Name and select **Add** > **New File...** > **Mac** > **Storyboard**. Enter a **Name** for the new Storyboard and click the **New** button: 
 
-    [![](indepth-images/ref01.png "Adding a new Storyboard")](indepth-images/ref01.png#lightbox)
+    [![Adding a new Storyboard](indepth-images/ref01.png)](indepth-images/ref01.png#lightbox)
 2. In the **Solution Explorer**, double-click the new Storyboard name to open it for editing in Xcode's Interface Builder.
 3. Design the layout of the new Storyboard's scenes as you normally would and save your changes: 
 
-    [![](indepth-images/ref02.png "Designing the interface")](indepth-images/ref02.png#lightbox)
+    [![Designing the interface](indepth-images/ref02.png)](indepth-images/ref02.png#lightbox)
 4. Switch to the Storyboard that you are going to be adding the reference to in the Interface Builder.
 5. Drag a **Storyboard Reference** from the **Object Library** onto the Design Surface: 
 
-    [![](indepth-images/ref03.png "Selecting a Storyboard Reference in the Library")](indepth-images/ref03.png#lightbox)
+    [![Selecting a Storyboard Reference in the Library](indepth-images/ref03.png)](indepth-images/ref03.png#lightbox)
 6. In the **Attribute Inspector**, select the name of the **Storyboard** that you created above: 
 
-    [![](indepth-images/ref04.png "Configuring the reference")](indepth-images/ref04.png#lightbox)
+    [![Configuring the reference](indepth-images/ref04.png)](indepth-images/ref04.png#lightbox)
 7. Control-click on a UI Widget (like a Button) on an existing Scene and create a new Segue to the **Storyboard Reference** that you just created.  From the popup menu select **Show** to complete the Segue: 
 
-    [![](indepth-images/ref06.png "Setting the Segue type")](indepth-images/ref06.png#lightbox) 
+    [![Setting the Segue type](indepth-images/ref06.png)](indepth-images/ref06.png#lightbox) 
 8. Save your changes to the Storyboard.
 9. Return to Visual Studio for Mac to sync your changes.
 
@@ -295,20 +295,20 @@ To add a reference to a specific Scene an external Storyboard (and not the Initi
 1. In the **Solution Explorer**, double-click the external Storyboard to open it for editing in Xcode's Interface Builder.
 2. Add a new Scene and design its layout as you normally would: 
 
-    [![](indepth-images/ref07.png "Designing the layout in Xcode")](indepth-images/ref07.png#lightbox)
+    [![Designing the layout in Xcode](indepth-images/ref07.png)](indepth-images/ref07.png#lightbox)
 3. In the **Identity Inspector**, enter a **Storyboard ID** for the new Scene's Window Controller: 
 
-    [![](indepth-images/ref08.png "Setting the Storyboard ID")](indepth-images/ref08.png#lightbox)
+    [![Setting the Storyboard ID](indepth-images/ref08.png)](indepth-images/ref08.png#lightbox)
 4. Open the Storyboard that you are going to be adding the reference to in Interface Builder.
 5. Drag a **Storyboard Reference** from the **Object Library** onto the Design Surface: 
 
-    [![](indepth-images/ref03.png "Selecting a Storyboard Reference from the Library")](indepth-images/ref03.png#lightbox)
+    [![Selecting a Storyboard Reference from the Library](indepth-images/ref03.png)](indepth-images/ref03.png#lightbox)
 6. In the **Identity Inspector**, select the name of the **Storyboard** and the **Reference ID** (Storyboard ID) of the Scene that you created above: 
 
-    [![](indepth-images/ref09.png "Setting the Reference ID")](indepth-images/ref09.png#lightbox)
+    [![Setting the Reference ID](indepth-images/ref09.png)](indepth-images/ref09.png#lightbox)
 7. Control-click on a UI Widget (like a Button) on an existing Scene and create a new Segue to the **Storyboard Reference** that you just created. From the popup menu select **Show** to complete the Segue: 
 
-    [![](indepth-images/ref06.png "Setting the Segue Type")](indepth-images/ref06.png#lightbox) 
+    [![Setting the Segue Type](indepth-images/ref06.png)](indepth-images/ref06.png#lightbox) 
 8. Save your changes to the Storyboard.
 9. Return to Visual Studio for Mac to sync your changes.
 
@@ -323,19 +323,19 @@ To add a reference to a specific Scene the same Storyboard, do the following:
 1. In the **Solution Explorer**, double-click the Storyboard to open it for editing.
 2. Add a new Scene and design its layout as you normally would: 
 
-    [![](indepth-images/ref11.png "Editing the storyboard in Xcode")](indepth-images/ref11.png#lightbox)
+    [![Editing the storyboard in Xcode](indepth-images/ref11.png)](indepth-images/ref11.png#lightbox)
 3. In the **Identity Inspector**, enter a **Storyboard ID** for the new Scene's Window Controller: 
 
-    [![](indepth-images/ref12.png "Setting the Storyboard ID")](indepth-images/ref12.png#lightbox)
+    [![Setting the Storyboard ID](indepth-images/ref12.png)](indepth-images/ref12.png#lightbox)
 4. Drag a **Storyboard Reference** from the **Toolbox** onto the Design Surface: 
 
-    [![](indepth-images/ref03.png "Selecting a Storyboard Reference from the Library")](indepth-images/ref03.png#lightbox)
+    [![Selecting a Storyboard Reference from the Library](indepth-images/ref03.png)](indepth-images/ref03.png#lightbox)
 5. In **Attribute Inspector**, select **Reference ID** (Storyboard ID) of the Scene that you created above: 
 
-    [![](indepth-images/ref13.png "Setting the Reference ID")](indepth-images/ref13.png#lightbox)
+    [![Setting the Reference ID](indepth-images/ref13.png)](indepth-images/ref13.png#lightbox)
 6. Control-click on a UI Widget (like a Button) on an existing Scene and create a new Segue to the **Storyboard Reference** that you just created. From the popup menu select **Show** to complete the Segue: 
 
-    [![](indepth-images/ref06.png "Selecting the Segue Type")](indepth-images/ref06.png#lightbox) 
+    [![Selecting the Segue Type](indepth-images/ref06.png)](indepth-images/ref06.png#lightbox) 
 7. Save your changes to the Storyboard.
 8. Return to Visual Studio for Mac to sync your changes.
 

--- a/docs/tools/profiler/index.md
+++ b/docs/tools/profiler/index.md
@@ -96,13 +96,13 @@ Before you can successfully Profile your app, you will need to allow Profiling i
 
   **Build > iOS Debug > Enable Profiling**
 
-  ![](images/ios-options-mac.png "iOS Options Dialog in Visual Studio for Mac")
+  ![iOS Options Dialog in Visual Studio for Mac](images/ios-options-mac.png)
 
 # [Visual Studio](#tab/windows)
 
   **Properties > iOS Build > Enable Profiling**
 
-  ![](images/ios-project-options-vs.png "iOS Options Dialog in Visual Studio")
+  ![iOS Options Dialog in Visual Studio](images/ios-project-options-vs.png)
 
 -----
 
@@ -133,7 +133,7 @@ The Xamarin Profiler can be launched from your IDE when you are profiling your i
 1. First, make sure you have your application loaded in Visual Studio for Mac, and select the (default) Debug configuration.
 2. Browse to **Run > Start Profiling**in Visual Studio for Mac, or **Analyze > Xamarin Profiler** in Visual Studio, to open the Profiler, as demonstrated in the diagram below:
 
-  ![](images/start-profiling-xs.png "Launching the Profiler from Visual Studio for Mac")
+  ![Launching the Profiler from Visual Studio for Mac](images/start-profiling-xs.png)
 
 # [Visual Studio](#tab/windows)
 
@@ -160,13 +160,13 @@ To save a profiling session at any time, choose **File > Save As...** from the P
 
 After it has been installed the Xamarin Profiler can be found in your Applications folder as illustrated in the screenshot below:
 
-![](images/applications.png "Open standalone Profiler from Mac")
+![Open standalone Profiler from Mac](images/applications.png)
 
 # [Visual Studio](#tab/windows)
 
 After it has been installed the Xamarin Profiler application can be found in your Application directory:
 
-![](images/applications-vs.png "Open standalone Profiler from Windows ")
+![Open standalone Profiler from Windows](images/applications-vs.png)
 
 -----
 
@@ -180,11 +180,11 @@ The Xamarin Profiler is composed of five sections as illustrated below:
 
 # [Visual Studio for Mac](#tab/macos)
 
-[![](images/profiler-mac-sml.png "Profiler sections in Visual Studio for Mac")](images/profiler-mac.png#lightbox) 
+[![Profiler sections in Visual Studio for Mac](images/profiler-mac-sml.png)](images/profiler-mac.png#lightbox) 
 
 # [Visual Studio](#tab/windows)
 
-[![](images/profiler-vs.png "Profiler sections in Visual Studio")](images/profiler-vs.png#lightbox)
+[![Profiler sections in Visual Studio](images/profiler-vs.png)](images/profiler-vs.png#lightbox)
 
 -----
 
@@ -202,11 +202,11 @@ At the top of the profiler is the allocations chart, which displays the amount o
 
 # [Visual Studio for Mac](#tab/macos)
 
-[![](images/allocations1.png "Allocations Instrument")](images/allocations1.png#lightbox) 
+[![Allocations Instrument](images/allocations1.png)](images/allocations1.png#lightbox) 
 
 # [Visual Studio](#tab/windows)
 
-[![](images/allocations1-vs.png "Allocations Instrument")](images/allocations1-vs.png#lightbox)
+[![Allocations Instrument](images/allocations1-vs.png)](images/allocations1-vs.png#lightbox)
 
 -----
 
@@ -216,11 +216,11 @@ There are different data views in the Allocations instrument, which allow develo
 
 # [Visual Studio for Mac](#tab/macos)
 
-  [![](images/allocations3.png "Allocations Tab")](images/allocations3.png#lightbox) 
+  [![Allocations Tab](images/allocations3.png)](images/allocations3.png#lightbox) 
 
 # [Visual Studio](#tab/windows)
 
-  [![](images/allocations2-vs.png "Allocations Tab")](images/allocations2-vs.png#lightbox)
+  [![Allocations Tab](images/allocations2-vs.png)](images/allocations2-vs.png#lightbox)
 
 -----
 
@@ -232,11 +232,11 @@ The Inspector view for Allocations provides options for filtering and grouping o
 
 # [Visual Studio for Mac](#tab/macos)
 
-  [![](images/allocations2.png "Call Tree Tab")](images/allocations2.png#lightbox) 
+  [![Call Tree Tab](images/allocations2.png)](images/allocations2.png#lightbox) 
 
 # [Visual Studio](#tab/windows)
 
-  [![](images/allocations3-vs.png "Call Tree Tab")](images/allocations3-vs.png#lightbox)
+  [![Call Tree Tab](images/allocations3-vs.png)](images/allocations3-vs.png#lightbox)
 
 -----
 
@@ -244,11 +244,11 @@ The Inspector view for Allocations provides options for filtering and grouping o
 
 # [Visual Studio for Mac](#tab/macos)
 
-  [![](images/allocations4.png "Snapshots Tab")](images/allocations4.png#lightbox) 
+  [![Snapshots Tab](images/allocations4.png)](images/allocations4.png#lightbox) 
 
 # [Visual Studio](#tab/windows)
 
-  [![](images/allocations4-vs.png "Snapshots Tab")](images/allocations4-vs.png#lightbox)
+  [![Snapshots Tab](images/allocations4-vs.png)](images/allocations4-vs.png#lightbox)
 
 -----
 
@@ -276,11 +276,11 @@ The plot chart, as shown in the screenshot below, displays the number of samples
 
 # [Visual Studio for Mac](#tab/macos)
 
-  [![](images/time2.png "Time Profiler Instrument – Call Tree")](images/time2.png#lightbox) 
+  [![Time Profiler Instrument – Call Tree](images/time2.png)](images/time2.png#lightbox) 
 
 # [Visual Studio](#tab/windows)
 
-  [![](images/time2-vs.png "Time Profiler Instrument – Call Tree")](images/time2-vs.png#lightbox) 
+  [![Time Profiler Instrument – Call Tree](images/time2-vs.png)](images/time2-vs.png#lightbox) 
 
 -----
 
@@ -311,7 +311,7 @@ If you profile an app with any other configuration, you will be presented with t
 
 # [Visual Studio](#tab/windows)
 
-[![](images/image1vs.png "Profiling Error Dialog")](images/image1vs.png#lightbox) 
+[![Profiling Error Dialog](images/image1vs.png)](images/image1vs.png#lightbox) 
 
 -----
 

--- a/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/arcs.md
+++ b/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/arcs.md
@@ -17,7 +17,7 @@ _Learn how to use SkiaSharp to define arcs in three different ways_
 
 An arc is a curve on the circumference of an ellipse, such as the rounded parts of this infinity sign:
 
-![](arcs-images/arcsample.png "Infinity sign")
+![Infinity sign](arcs-images/arcsample.png)
 
 Despite the simplicity of that definition, there is no way to define an arc-drawing function that satisfies every need, and hence, no consensus among graphics systems of the best way to draw an arc. For this reason, the `SKPath` class does not restrict itself to just one approach.
 
@@ -37,21 +37,21 @@ These methods are identical to the Android [`AddArc`](xref:Android.Graphics.Path
 
 Both methods begin with an `SKRect` value that defines both the location and size of an ellipse:
 
-![](arcs-images/anglearcoval.png "The oval that begins an angle arc")
+![The oval that begins an angle arc](arcs-images/anglearcoval.png)
 
 The arc is a part of the circumference of this ellipse.
 
 The `startAngle` argument is a clockwise angle in degrees relative to a horizontal line drawn from the center of the ellipse to the right. The `sweepAngle` argument is relative to the `startAngle`. Here are `startAngle` and `sweepAngle` values of 60 degrees and 100 degrees, respectively:
 
-![](arcs-images/anglearcangles.png "The angles that define an angle arc")
+![The angles that define an angle arc](arcs-images/anglearcangles.png)
 
 The arc begins at the start angle. Its length is governed by the sweep angle. The arc is shown here in red:
 
-![](arcs-images/anglearchighlight.png "The highlighted angle arc")
+![The highlighted angle arc](arcs-images/anglearchighlight.png)
 
 The curve added to the path with the `AddArc` or `ArcTo` method is simply that part of the ellipse's circumference:
 
-![](arcs-images/anglearc.png "The angle arc by itself")
+![The angle arc by itself](arcs-images/anglearc.png)
 
 The `startAngle` or `sweepAngle` arguments can be negative: The arc is clockwise for positive values of `sweepAngle` and counter-clockwise for negative values.
 
@@ -98,7 +98,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 As you can see, both the start angle and the sweep angle can take on negative values:
 
-[![](arcs-images/anglearc-small.png "Triple screenshot of the Angle Arc page")](arcs-images/anglearc-large.png#lightbox "Triple screenshot of the Angle Arc page")
+[![Triple screenshot of the Angle Arc page](arcs-images/anglearc-small.png)](arcs-images/anglearc-large.png#lightbox)
 
 This approach to generating an arc is algorithmically the simplest, and it's easy to derive the parametric equations that describe the arc. Knowing the size and location of the ellipse, and the start and sweep angles, the start and end points of the arc can be calculated using simple trigonometry:
 
@@ -203,11 +203,11 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 A new `SKPath` object is created for each pie slice. The path consists of a line from the center, then an `ArcTo` to draw the arc, and another line back to the center results from the `Close` call. This program displays "exploded" pie slices by moving them all out from the center by 50 pixels. That task requires a vector in the direction of the midpoint of the sweep angle for each slice:
 
-[![](arcs-images/explodedpiechart-small.png "Triple screenshot of the Exploded Pie Chart page")](arcs-images/explodedpiechart-large.png#lightbox "Triple screenshot of the Exploded Pie Chart page")
+[![Triple screenshot of the Exploded Pie Chart page](arcs-images/explodedpiechart-small.png)](arcs-images/explodedpiechart-large.png#lightbox)
 
 To see what it looks like without the "explosion," simply comment out the `Translate` call:
 
-[![](arcs-images/explodedpiechartunexploded-small.png "Triple screenshot of the Exploded Pie Chart page without the explosion")](arcs-images/explodedpiechartunexploded-large.png#lightbox "Triple screenshot of the Exploded Pie Chart page without the explosion")
+[![Triple screenshot of the Exploded Pie Chart page without the explosion](arcs-images/explodedpiechartunexploded-small.png)](arcs-images/explodedpiechartunexploded-large.png#lightbox)
 
 ## The Tangent Arc
 
@@ -229,31 +229,31 @@ The `ArcTo` method involves three points:
 - The first point argument to the `ArcTo` method, called the *corner point*
 - The second point argument to `ArcTo`, called the *destination point*:
 
-![](arcs-images/tangentarcthreepoints.png "Three points that begin a tangent arc")
+![Three points that begin a tangent arc](arcs-images/tangentarcthreepoints.png)
 
 These three points define two connected lines:
 
-![](arcs-images/tangentarcconnectinglines.png "Lines connecting the three points of a tangent arc")
+![Lines connecting the three points of a tangent arc](arcs-images/tangentarcconnectinglines.png)
 
 If the three points are colinear &mdash; that is, if they lie on the same straight line &mdash; no arc will be drawn.
 
 The `ArcTo` method also includes a `radius` parameter. This defines the radius of a circle:
 
-![](arcs-images/tangentarccircle.png "The circle of a tangent arc")
+![The circle of a tangent arc](arcs-images/tangentarccircle.png)
 
 The tangent arc is not generalized for an ellipse.
 
 If the two lines meet at any angle, that circle can be inserted between those lines so that it is tangent to both lines:
 
-![](arcs-images/tangentarctangentcircle.png "The tangent arc circle between the two lines")
+![The tangent arc circle between the two lines](arcs-images/tangentarctangentcircle.png)
 
 The curve that is added to the contour does not touch either of the points specified in the `ArcTo` method. It consists of a straight line from the current point to the first tangent point, and an arc that ends at the second tangent point, shown here in red:
 
-![](arcs-images/tangentarchighlight.png "The highlighted tangent arc between the two lines")
+![The highlighted tangent arc between the two lines](arcs-images/tangentarchighlight.png)
 
 Here's the final straight line and arc that is added to the contour:
 
-![](arcs-images/tangentarc.png "The highlighted tangent arc between the two lines")
+![The highlighted tangent arc between the two lines](arcs-images/tangentarc.png)
 
 The contour can be continued from the second tangent point.
 
@@ -411,7 +411,7 @@ public partial class TangentArcPage : InteractivePage
 
 Here's the **Tangent Arc** page running:
 
-[![](arcs-images/tangentarc-small.png "Triple screenshot of the Tangent Arc page")](arcs-images/tangentarc-large.png#lightbox "Triple screenshot of the Tangent Arc page")
+[![Triple screenshot of the Tangent Arc page](arcs-images/tangentarc-small.png)](arcs-images/tangentarc-large.png#lightbox)
 
 The tangent arc is ideal for creating rounded corners, such as a rounded rectangle. Because `SKPath` already includes an `AddRoundedRect` method, the **Rounded Heptagon** page demonstrates how to use `ArcTo` for rounding the corners of a seven-sided polygon. (The code is generalized for any regular polygon.)
 
@@ -486,7 +486,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 Here's the program running:
 
-[![](arcs-images/roundedheptagon-small.png "Triple screenshot of the Rounded Heptagon page")](arcs-images/roundedheptagon-large.png#lightbox "Triple screenshot of the Rounded Heptagon page")
+[![Triple screenshot of the Rounded Heptagon page](arcs-images/roundedheptagon-small.png)](arcs-images/roundedheptagon-large.png#lightbox)
 
 ## The Elliptical Arc
 
@@ -502,31 +502,31 @@ The elliptical arc is consistent with the [elliptical arc](http://www.w3.org/TR/
 
 These `ArcTo` methods draw an arc between two points, which are the current point of the contour, and the last parameter to the `ArcTo` method (the `xy` parameter or the separate `x` and `y` parameters):
 
-![](arcs-images/ellipticalarcpoints.png "The two points that defined an elliptical arc")
+![The two points that defined an elliptical arc](arcs-images/ellipticalarcpoints.png)
 
 The first point parameter to the `ArcTo` method (`r`, or `rx` and `ry`) is not a point at all but instead specifies the horizontal and vertical radii of an ellipse;
 
-![](arcs-images/ellipticalarcellipse.png "The ellipse that defined an elliptical arc")
+![The ellipse that defined an elliptical arc](arcs-images/ellipticalarcellipse.png)
 
 The `xAxisRotate` parameter is the number of clockwise degrees to rotate this ellipse:
 
-![](arcs-images/ellipticalarctiltedellipse.png "The tilted ellipse that defined an elliptical arc")
+![The tilted ellipse that defined an elliptical arc](arcs-images/ellipticalarctiltedellipse.png)
 
 If this tilted ellipse is then positioned so that it touches the two points, the points are connected by two different arcs:
 
-![](arcs-images/ellipticalarcellipse1.png "The first set of elliptical arcs")
+![The first set of elliptical arcs](arcs-images/ellipticalarcellipse1.png)
 
 These two arcs can be distinguished in two ways: The top arc is larger than the bottom arc, and as the arc is drawn from left to right, the top arc is drawn in a clockwise direction while the bottom arc is drawn in a counter-clockwise direction.
 
 It is also possible to fit the ellipse between the two points in another way:
 
-![](arcs-images/ellipticalarcellipse2.png "The second set of elliptical arcs")
+![The second set of elliptical arcs](arcs-images/ellipticalarcellipse2.png)
 
 Now there's a smaller arc on top that's drawn clockwise, and a larger arc on the bottom that's drawn counter-clockwise.
 
 These two points can therefore be connected by an arc defined by the tilted ellipse in a total of four ways:
 
-![](arcs-images/ellipticalarccolors.png "All four elliptical arcs")
+![All four elliptical arcs](arcs-images/ellipticalarccolors.png)
 
 These four arcs are distinguished by the four combinations of the [`SKPathArcSize`](xref:SkiaSharp.SKPathArcSize) and [`SKPathDirection`](xref:SkiaSharp.SKPathDirection) enumeration type arguments to the `ArcTo` method:
 
@@ -581,21 +581,21 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 Here it is running:
 
-[![](arcs-images/ellipticalarc-small.png "Triple screenshot of the Elliptical Arc page")](arcs-images/ellipticalarc-large.png#lightbox "Triple screenshot of the Elliptical Arc page")
+[![Triple screenshot of the Elliptical Arc page](arcs-images/ellipticalarc-small.png)](arcs-images/ellipticalarc-large.png#lightbox)
 
 The **Arc Infinity** page uses the elliptical arc to draw an infinity sign. The infinity sign is based on two circles with radii of 100 units separated by 100 units:
 
-![](arcs-images/infinitycircles.png "Two circles")
+![Two circles](arcs-images/infinitycircles.png)
 
 Two lines crossing each other are tangent to both circles:
 
-![](arcs-images/infinitycircleslines.png "Two circles with tangent lines")
+![Two circles with tangent lines](arcs-images/infinitycircleslines.png)
 
 The infinity sign is a combination of parts of these circles and the two lines. To use the elliptical arc to draw the infinity sign, the coordinates where the two lines are tangent to the circles must be determined.
 
 Construct a right rectangle in one of the circles:
 
-![](arcs-images/infinitytriangle.png "Two circles with tangent lines and embedded circle")
+![Two circles with tangent lines and embedded circle](arcs-images/infinitytriangle.png)
 
 The radius of the circle is 100 units, and the hypotenuse of the triangle is 150 units, so the angle α is the arcsine (inverse sine) of 100 divided by 150, or 41.8 degrees. The length of the other side of the triangle is 150 times the cosine of 41.8 degrees, or 112, which can also be calculated by the Pythagorean theorem.
 
@@ -607,7 +607,7 @@ The coordinates of the tangent point can then be calculated using this informati
 
 The four tangent points are all that's necessary to draw an infinity sign centered on the point (0, 0) with circle radii of 100:
 
-![](arcs-images/infinitycoordinates.png "Two circles with tangent lines and coordinates")
+![Two circles with tangent lines and coordinates](arcs-images/infinitycoordinates.png)
 
 The `PaintSurface` handler in the [`ArcInfinityPage`](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/ArcInfinityPage.cs) class positions the infinity sign so that the (0, 0) point is positioned in the center of the page, and scales the path to the screen size:
 
@@ -649,7 +649,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 The code uses the `Bounds` property of `SKPath` to determine the dimensions of the infinity sine to scale it to the size of the canvas:
 
-[![](arcs-images/arcinfinity-small.png "Triple screenshot of the Arc Infinity page")](arcs-images/arcinfinity-large.png#lightbox "Triple screenshot of the Arc Infinity page")
+[![Triple screenshot of the Arc Infinity page](arcs-images/arcinfinity-small.png)](arcs-images/arcinfinity-large.png#lightbox)
 
 The result seems a little small, which suggests that the `Bounds` property of `SKPath` is reporting a size larger than the path.
 
@@ -657,7 +657,7 @@ Internally, Skia approximates the arc using multiple quadratic Bézier curves. T
 
 To get a tighter fit, use the `TightBounds` property, which excludes the control points. Here's the program running in landscape mode, and using the `TightBounds` property to obtain the path bounds:
 
-[![](arcs-images/arcinfinitytightbounds-small.png "Triple screenshot of the Arc Infinity page with tight bounds")](arcs-images/arcinfinitytightbounds-large.png#lightbox "Triple screenshot of the Arc Infinity page with tight bounds")
+[![Triple screenshot of the Arc Infinity page with tight bounds](arcs-images/arcinfinitytightbounds-small.png)](arcs-images/arcinfinitytightbounds-large.png#lightbox)
 
 Although the connections between the arcs and straight lines are mathematically smooth, the change from arc to straight line might seem a little abrupt. A better infinity sign is presented in the next article on [**Three Types of Bézier Curves**](beziers.md).
 

--- a/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/beziers.md
+++ b/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/beziers.md
@@ -19,7 +19,7 @@ The Bézier curve is named after Pierre Bézier (1910 – 1999), a French engine
 
 Bézier curves are known for being well-suited to interactive design: They are well behaved &mdash; in other words, there aren't singularities that cause the curve to become infinite or unwieldy &mdash; and they are generally aesthetically pleasing:
 
-![](beziers-images/beziersample.png "A sample Bezier curve")
+![A sample Bezier curve](beziers-images/beziersample.png)
 
 Character outlines of computer-based fonts are usually defined with Bézier curves.
 
@@ -88,7 +88,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 Here it is running:
 
-[![](beziers-images/beziercurve-small.png "Triple screenshot of the Bezier Curve page")](beziers-images/beziercurve-large.png#lightbox "Triple screenshot of the Bezier Curve page")
+[![Triple screenshot of the Bezier Curve page](beziers-images/beziercurve-small.png)](beziers-images/beziercurve-large.png#lightbox)
 
 Mathematically, the curve is a cubic polynomial. The curve intersects a straight line at three points at most. At the start point, the curve is always tangent to, and in the same direction as, a straight line from the start point to the first control point. At the end point, the curve is always tangent to, and in the same direction as, a straight line from the second control point to the end point.
 
@@ -120,7 +120,7 @@ It is sometimes convenient to use a Bézier curve to render a circular arc. A cu
 
 The following diagram shows four points labeled `pto`, `pt1`, `pt2`, and `pt3` defining a Bézier curve (shown in red) that approximates a circular arc:
 
-![](beziers-images/bezierarc45.png "Approximation of a circular arc with a Bézier curve")
+![Approximation of a circular arc with a Bézier curve](beziers-images/bezierarc45.png)
 
 The lines from the start and end points to the control points are tangent to the circle and to the Bézier curve, and they have a length of *L*. The first article cited above indicates that the Bézier curve best approximates a circular arc when that length *L* is calculated like this:
 
@@ -206,13 +206,13 @@ The start and end points (`point0` and `point3`) are calculated based on the nor
 
 Here's the program running with different angles:
 
-[![](beziers-images/beziercirculararc-small.png "Triple screenshot of the Bezier Circular Arc page")](beziers-images/beziercirculararc-large.png#lightbox "Triple screenshot of the Bezier Circular Arc page")
+[![Triple screenshot of the Bezier Circular Arc page](beziers-images/beziercirculararc-small.png)](beziers-images/beziercirculararc-large.png#lightbox)
 
 Look closely at the third screenshot, and you'll see that the Bézier curve notably deviates from a semicircle when the angle is 180 degrees, but the iOS screen shows that it seems to fit a quarter-circle just fine when the angle is 90 degrees.
 
 Calculating the coordinates of the two control points is quite easy when the quarter circle is oriented like this:
 
-![](beziers-images/bezierarc90.png "Approximation of a quarter circle with a Bézier curve")
+![Approximation of a quarter circle with a Bézier curve](beziers-images/bezierarc90.png)
 
 If the radius of the circle is 100, then *L* is 55, and that's an easy number to remember.
 
@@ -288,7 +288,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 The points are interpolated based on a sinusoidally oscillating value of `t`. The interpolated points are then used to construct a series of four connected Bézier curves. Here's the animation running:
 
-[![](beziers-images/squaringthecircle-small.png "Triple screenshot of the Squaring the Circle page")](beziers-images/squaringthecircle-large.png#lightbox "Triple screenshot of the Squaring the Circle page")
+[![Triple screenshot of the Squaring the Circle page](beziers-images/squaringthecircle-small.png)](beziers-images/squaringthecircle-large.png#lightbox)
 
 Such an animation would be impossible without curves that are algorithmically flexible enough to be rendered as both circular arcs and straight lines.
 
@@ -337,7 +337,7 @@ It might be a good exercise to plot these coordinates on graph paper to see how 
 
 Here's the infinity sign:
 
-[![](beziers-images/bezierinfinity-small.png "Triple screenshot of the Bézier Infinity page")](beziers-images/bezierinfinity-large.png#lightbox "Triple screenshot of the Bézier Infinity page")
+[![Triple screenshot of the Bézier Infinity page](beziers-images/bezierinfinity-small.png)](beziers-images/bezierinfinity-large.png#lightbox)
 
 It is somewhat smoother towards the center than the infinity sign rendered by the **Arc Infinity** page from the [**Three Ways to Draw an Arc**](~/xamarin-forms/user-interface/graphics/skiasharp/curves/arcs.md) article.
 
@@ -400,7 +400,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 And here it is running:
 
-[![](beziers-images/quadraticcurve-small.png "Triple screenshot of the Quadratic Curve page")](beziers-images/quadraticcurve-large.png#lightbox "Triple screenshot of the Quadratic Curve page")
+[![Triple screenshot of the Quadratic Curve page](beziers-images/quadraticcurve-small.png)](beziers-images/quadraticcurve-large.png#lightbox)
 
 The dotted lines are tangent to the curve at the start point and end point, and meet at the control point.
 
@@ -478,7 +478,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 Here it is running:
 
-[![](beziers-images/coniccurve-small.png "Triple screenshot of the Conic Curve page")](beziers-images/coniccurve-large.png#lightbox "Triple screenshot of the Conic Curve page")
+[![Triple screenshot of the Conic Curve page](beziers-images/coniccurve-small.png)](beziers-images/coniccurve-large.png#lightbox)
 
 As you can see, the control point seems to pull the curve towards it more when the weight is higher. When the weight is zero, the curve becomes a straight line from the start point to the end point.
 
@@ -486,7 +486,7 @@ In theory, negative weights are allowed, and cause the curve to bend *away* from
 
 It is very easy to derive the control point and weight to use the `ConicTo` method to draw a circular arc up to (but not including) a semicircle. In the following diagram, tangent lines from the start and end points meet at the control point.
 
-![](beziers-images/conicarc.png "A conic arc rendering of a circular arc")
+![A conic arc rendering of a circular arc](beziers-images/conicarc.png)
 
 You can use trigonometry to determine the distance of the control point from the circle's center: It is the radius of the circle divided by the cosine of half the angle α. To draw a circular arc between the start and end points, set the weight to that same cosine of half the angle. Notice that if the angle is 180 degrees, then the tangent lines never meet and the weight is zero. But for angles less than 180 degrees, the math works fine.
 
@@ -542,7 +542,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 As you can see, there is no visual difference between the `ConicTo` path shown in red and the underlying circle displayed for reference:
 
-[![](beziers-images/coniccirculararc-small.png "Triple screenshot of the Conic Circular Arc page")](beziers-images/coniccirculararc-large.png#lightbox "Triple screenshot of the Conic Circular Arc page")
+[![Triple screenshot of the Conic Circular Arc page](beziers-images/coniccirculararc-small.png)](beziers-images/coniccirculararc-large.png#lightbox)
 
 But set the angle to 180 degrees, and the mathematics fail.
 

--- a/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/clipping.md
+++ b/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/clipping.md
@@ -17,7 +17,7 @@ _Use paths to clip graphics to specific areas, and to create regions_
 
 It's sometimes necessary to restrict the rendering of graphics to a particular area. This is known as *clipping*. You can use clipping for special effects, such as this image of a monkey seen through a keyhole:
 
-![](clipping-images/clippingsample.png "Monkey through a keyhole")
+![Monkey through a keyhole](clipping-images/clippingsample.png)
 
 The *clipping area* is the area of the screen in which graphics are rendered. Anything that is displayed outside of the clipping area is not rendered. The clipping area is usually defined by a rectangle or an [`SKPath`](xref:SkiaSharp.SKPath) object, but you can alternatively define a clipping area using an [`SKRegion`](xref:SkiaSharp.SKRegion) object. These two types of objects at first seem related because you can create a region from a path. However, you cannot create a path from a region, and they are very different internally: A path comprises a series of lines and curves, while a region is defined by a series of horizontal scan lines.
 
@@ -95,7 +95,7 @@ canvas.ClipPath(keyholePath);
 
 The `PaintSurface` handler then resets the transforms with a call to `ResetMatrix` and draws the bitmap to extend to the full height of the screen. This code assumes that the bitmap is square, which this particular bitmap is. The bitmap is rendered only within the area defined by the clipping path:
 
-[![](clipping-images/monkeythroughkeyhole-small.png "Triple screenshot of the Monkey through Keyhole page")](clipping-images/monkeythroughkeyhole-large.png#lightbox "Triple screenshot of the Monkey through Keyhole page")
+[![Triple screenshot of the Monkey through Keyhole page](clipping-images/monkeythroughkeyhole-small.png)](clipping-images/monkeythroughkeyhole-large.png#lightbox)
 
 The clipping path is subject to the transforms in effect when the `ClipPath` method is called, and not to the transforms in effect when a graphical object (such as a bitmap) is displayed. The clipping path is part of the canvas state that is saved with the `Save` method and restored with the `Restore` method.
 
@@ -162,7 +162,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 What's left is the intersection of these four circles:
 
-[![](clipping-images//fourcircleintersectclip-small.png "Triple screenshot of the Four Circle Intersect Clip page")](clipping-images/fourcircleintersectclip-large.png#lightbox "Triple screenshot of the Four Circle Intersect Clip page")
+[![Triple screenshot of the Four Circle Intersect Clip page](clipping-images//fourcircleintersectclip-small.png)](clipping-images/fourcircleintersectclip-large.png#lightbox)
 
 The [`SKClipOperation`](xref:SkiaSharp.SKClipOperation) enumeration has only two members:
 
@@ -172,13 +172,13 @@ The [`SKClipOperation`](xref:SkiaSharp.SKClipOperation) enumeration has only two
 
 If you replace the four `SKClipOperation.Intersect` arguments in the `FourCircleIntersectClipPage` class with `SKClipOperation.Difference`, you'll see the following:
 
-[![](clipping-images//fourcircledifferenceclip-small.png "Triple screenshot of the Four Circle Intersect Clip page with difference operation")](clipping-images/fourcircledifferenceclip-large.png#lightbox "Triple screenshot of the Four Circle Intersect Clip page with difference operation")
+[![Triple screenshot of the Four Circle Intersect Clip page with difference operation](clipping-images//fourcircledifferenceclip-small.png)](clipping-images/fourcircledifferenceclip-large.png#lightbox)
 
 Four overlapping circles have been removed from the clipping area.
 
 The **Clip Operations** page illustrates the difference between these two operations with just a pair of circles. The first circle on the left is added to the clipping area with the default clip operation of `Intersect`, while the second circle on the right is added to the clipping area with the clip operation indicated by the text label:
 
-[![](clipping-images//clipoperations-small.png "Triple screenshot of the Clip Operations page")](clipping-images/clipoperations-large.png#lightbox "Triple screenshot of the Clip Operations page")
+[![Triple screenshot of the Clip Operations page](clipping-images//clipoperations-small.png)](clipping-images/clipoperations-large.png#lightbox)
 
 The [`ClipOperationsPage`](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/ClipOperationsPage.cs) class defines two `SKPaint` objects as fields, and then divides the screen up into two rectangular areas. These areas are different depending on whether the phone is in portrait or landscape mode. The `DisplayClipOp` class then displays the text and calls `ClipPath` with the two circle paths to illustrate each clip operation:
 
@@ -277,7 +277,7 @@ public void ClipRegion(SKRegion region, SKClipOperation operation = SKClipOperat
 
 The following screenshot shows clipping areas based on the six region operations. The left circle is the region that the `Op` method is called on, and the right circle is the region passed to the `Op` method:
 
-[![](clipping-images//regionoperations-small.png "Triple screenshot of the Region Operations page")](clipping-images/regionoperations-large.png#lightbox "Triple screenshot of the Region Operations page")
+[![Triple screenshot of the Region Operations page](clipping-images//regionoperations-small.png)](clipping-images/regionoperations-large.png#lightbox)
 
 Are these all the possibilities of combining these two circles? Consider the resultant image as a combination of three components, which by themselves are seen in the `Difference`, `Intersect`, and `ReverseDifference` operations. The total number of combinations is two to the third power, or eight. The two that are missing are the original region (which results from not calling `Op` at all) and an entirely empty region.
 
@@ -418,7 +418,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 The `DrawRegion` call fills the region in orange, while the `DrawPath` call strokes the original path in blue for comparison:
 
-[![](clipping-images//regionpaint-small.png "Triple screenshot of the Region Paint page")](clipping-images/regionpaint-large.png#lightbox "Triple screenshot of the Region Paint page")
+[![Triple screenshot of the Region Paint page](clipping-images//regionpaint-small.png)](clipping-images/regionpaint-large.png#lightbox)
 
 The region is clearly a series of discrete coordinates.
 
@@ -504,7 +504,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 It doesn't really look like a four-leaf clover, but it's an image that might otherwise be hard to render without clipping:
 
-[![](clipping-images//fourleafclover-small.png "Triple screenshot of the Four-Leaf Clover page")](clipping-images/fourleafclover-large.png#lightbox "Triple screenshot of the Four-Leaf Clover page")
+[![Triple screenshot of the Four-Leaf Clover page](clipping-images//fourleafclover-small.png)](clipping-images/fourleafclover-large.png#lightbox)
 
 
 ## Related Links

--- a/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/effects.md
+++ b/docs/xamarin-forms/user-interface/graphics/skiasharp/curves/effects.md
@@ -17,7 +17,7 @@ _Discover the various path effects that allow paths to be used for stroking and 
 
 A *path effect* is an instance of the [`SKPathEffect`](xref:SkiaSharp.SKPathEffect) class that is created with one of eight static creation methods defined by the class. The `SKPathEffect` object is then set to the [`PathEffect`](xref:SkiaSharp.SKPaint.PathEffect) property of an [`SKPaint`](xref:SkiaSharp.SKPaint) object for a variety of interesting effects, for example, stroking a line with a small replicated path:
 
-![](effects-images/patheffectsample.png "The Linked Chain sample")
+![The Linked Chain sample](effects-images/patheffectsample.png)
 
 Path effects allow you to:
 
@@ -46,7 +46,7 @@ The ends of the dashes are affected by the `StrokeCap` property of `SKPaint`. Fo
 
 The **Animated Dotted Text** page is similar to the **Outlined Text** page described in the article [**Integrating Text and Graphics**](~/xamarin-forms/user-interface/graphics/skiasharp/basics/text.md) in that it displays outlined text characters by setting the `Style` property of the `SKPaint` object to `SKPaintStyle.Stroke`. In addition, **Animated Dotted Text** uses `SKPathEffect.CreateDash` to give this outline a dotted appearance, and the program also animates the `phase` argument of the `SKPathEffect.CreateDash` method to make the dots seem to travel around the text characters. Here's the page in landscape mode:
 
-[![](effects-images/animateddottedtext-small.png "Triple screenshot of the Animated Dotted Text page")](effects-images/animateddottedtext-large.png#lightbox "Triple screenshot of the Animated Dotted Text page")
+[![Triple screenshot of the Animated Dotted Text page](effects-images/animateddottedtext-small.png)](effects-images/animateddottedtext-large.png#lightbox)
 
 The [`AnimatedDottedTextPage`](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/DotDashMorphPage.cs) class begins by defining some constants, and also overrides the `OnAppearing` and `OnDisappearing` methods for the animation:
 
@@ -154,7 +154,7 @@ It's possible to adjust the length of the dash pattern to fit the length of the 
 
 The **Dot / Dash Morph** program animates the dash pattern itself so that dashes seem to divide into dots, which combine to form dashes again:
 
-[![](effects-images/dotdashmorph-small.png "Triple screenshot of the Dot Dash Morph page")](effects-images/dotdashmorph-large.png#lightbox "Triple screenshot of the Dot Dash Morph page")
+[![Triple screenshot of the Dot Dash Morph page](effects-images/dotdashmorph-small.png)](effects-images/dotdashmorph-large.png#lightbox)
 
 The [`DotDashMorphPage`](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/DotDashMorphPage.cs) class overrides the `OnAppearing` and `OnDisappearing` methods just as the previous program did, but the class defines the `SKPaint` object as a field:
 
@@ -393,7 +393,7 @@ public partial class OneDimensionalPathEffectPage : ContentPage
 
 The `PaintSurface` handler creates a Bézier curve that loops around itself, and accesses the picker to determine which `PathEffect` should be used to stroke it. The three options — `Translate`, `Rotate`, and `Morph` — are shown from left to right:
 
-[![](effects-images/1dpatheffect-small.png "Triple screenshot of the 1D Path Effect page")](effects-images/1dpatheffect-large.png#lightbox "Triple screenshot of the 1D Path Effect page")
+[![Triple screenshot of the 1D Path Effect page](effects-images/1dpatheffect-small.png)](effects-images/1dpatheffect-large.png#lightbox)
 
 The path specified in the `SKPathEffect.Create1DPath` method is always filled. The path specified in the `DrawPath` method is always stroked if the `SKPaint` object has its `PathEffect` property set to a 1D path effect. Notice that the `pathPaint` object has no `Style` setting, which normally defaults to `Fill`, but the path is stroked regardless.
 
@@ -405,7 +405,7 @@ The rectangle shape in the `Morph` example is 50 pixels wide with an `advance` s
 
 If the `advance` argument is less than the size of the path, then the replicated paths can overlap. This can result in some interesting effects. The **Linked Chain** page displays a series of overlapping circles that seem to resemble a linked chain, which hangs in the distinctive shape of a catenary:
 
-[![](effects-images/linkedchain-small.png "Triple screenshot of the Linked Chain page")](effects-images/linkedchain-large.png#lightbox "Triple screenshot of the Linked Chain page")
+[![Triple screenshot of the Linked Chain page](effects-images/linkedchain-small.png)](effects-images/linkedchain-large.png#lightbox)
 
 Look very close and you'll see that those aren't actually circles. Each link in the chain is two arcs, sized and positioned so they seem to connect with adjoining links.
 
@@ -544,7 +544,7 @@ This program defines the path used in `Create1DPath` to have its (0, 0) point in
 
 The **Conveyor Belt** page creates a path resembling an oblong conveyor belt with a curved top and bottom that is sized to the dimensions of the window. That path is stroked with a simple `SKPaint` object 20 pixels wide and colored gray, and then stroked again with another `SKPaint` object with an `SKPathEffect` object referencing a path resembling a little bucket:
 
-[![](effects-images/conveyorbelt-small.png "Triple screenshot of the Conveyor Belt page")](effects-images/conveyorbelt-large.png#lightbox "Triple screenshot of the Conveyor Belt page")
+[![Triple screenshot of the Conveyor Belt page](effects-images/conveyorbelt-small.png)](effects-images/conveyorbelt-large.png#lightbox)
 
 The (0, 0) point of the bucket path is the handle, so when the `phase` argument is animated, the buckets seem to revolve around the conveyor belt, perhaps scooping up water at the bottom and dumping it out at the top.
 
@@ -793,7 +793,7 @@ If you look carefully at the results, you'll see that the red and blue hatch lin
 
 The `PaintSurface` handler concludes with a call to simply stroke the rounded rectangle, so you can see the discrepancy with the red and blue hatch lines:
 
-[![](effects-images/hatchfill-small.png "Triple screenshot of the Hatch Fill page")](effects-images/hatchfill-large.png#lightbox "Triple screenshot of the Hatch Fill page")
+[![Triple screenshot of the Hatch Fill page](effects-images/hatchfill-small.png)](effects-images/hatchfill-large.png#lightbox)
 
 The Android screen doesn't really look like that: The scaling of the screenshot has caused the thin red lines and thin spaces to consolidate into seemingly wider red lines and wider spaces.
 
@@ -847,7 +847,7 @@ public class PathTileFillPage : ContentPage
 
 In the `PaintSurface` handler, the `SKPathEffect.Create2DPath` calls sets the horizontal and vertical spacing to 64 to cause the 80-pixel square tiles to overlap. Fortunately, the path resembles a puzzle piece, meshing nicely with adjoining tiles:
 
-[![](effects-images/pathtilefill-small.png "Triple screenshot of the Path Tile Fill page")](effects-images/pathtilefill-large.png#lightbox "Triple screenshot of the Path Tile Fill page")
+[![Triple screenshot of the Path Tile Fill page](effects-images/pathtilefill-small.png)](effects-images/pathtilefill-large.png#lightbox)
 
 The scaling from the original screenshot causes some distortion, particularly on the Android screen.
 
@@ -922,7 +922,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 You can use this effect with either stroking or filling based on the `Style` property of the `SKPaint` object. Here it is running:
 
-[![](effects-images/anotherroundedheptagon-small.png "Triple screenshot of the Another Rounded Heptagon page")](effects-images/anotherroundedheptagon-large.png#lightbox "Triple screenshot of the Another Rounded Heptagon page")
+[![Triple screenshot of the Another Rounded Heptagon page](effects-images/anotherroundedheptagon-small.png)](effects-images/anotherroundedheptagon-large.png#lightbox)
 
 You'll see that this rounded heptagon is identical to the earlier program. If you need more convincing that the corner radius is truly 100 rather than the 50 specified in the `SKPathEffect.CreateCorner` call, you can uncomment the final statement in the program and see a 100-radius circle superimposed on the corner.
 
@@ -941,7 +941,7 @@ The final argument is a seed used to generate the pseudo-random sequence used fo
 
 The **Jitter Experiment** page allows you to experiment with different values in stroking a rectangle:
 
-[![](effects-images/jitterexperiment-small.png "Triple screenshot of the Jitter Experiment page")](effects-images/jitterexperiment-large.png#lightbox "Triple screenshot of the JitterExperiment page")
+[![Triple screenshot of the JitterExperiment page](effects-images/jitterexperiment-small.png)](effects-images/jitterexperiment-large.png#lightbox)
 
 The program is straightforward. The [**JitterExperimentPage.xaml**](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/JitterExperimentPage.xaml) file instantiates two `Slider` elements and an `SKCanvasView`:
 
@@ -1067,7 +1067,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
 
 Here it is running in landscape mode:
 
-[![](effects-images/jittertext-small.png "Triple screenshot of the Jitter Text page")](effects-images/jittertext-large.png#lightbox "Triple screenshot of the JitterText page")
+[![Triple screenshot of the JitterText page](effects-images/jittertext-small.png)](effects-images/jittertext-large.png#lightbox)
 
 ## Path Outlining
 
@@ -1168,11 +1168,11 @@ public partial class TapToOutlineThePathPage : ContentPage
 
 The circle is filled and stroked as you'd expect:
 
-[![](effects-images/taptooutlinethepathnormal-small.png "Triple screenshot of the normal Tap To Outline The Path page")](effects-images/taptooutlinethepathnormal-large.png#lightbox "Triple screenshot of the normal Tap To Outline The Path page")
+[![Triple screenshot of the normal Tap To Outline The Path page](effects-images/taptooutlinethepathnormal-small.png)](effects-images/taptooutlinethepathnormal-large.png#lightbox)
 
 When you tap the screen, `outlineThePath` is set to `true`, and the `PaintSurface` handler creates a fresh `SKPath` object and uses that as the destination path in a call to `GetFillPath` on the `redThickStroke` paint object. That destination path is then filled and stroked with `redThinStroke`, resulting in the following:
 
-[![](effects-images/taptooutlinethepathoutlined-small.png "Triple screenshot of the outlined Tap To Outline The Path page")](effects-images/taptooutlinethepathoutlined-large.png#lightbox "Triple screenshot of the outlined Tap To Outline The Path page")
+[![Triple screenshot of the outlined Tap To Outline The Path page](effects-images/taptooutlinethepathoutlined-small.png)](effects-images/taptooutlinethepathoutlined-large.png#lightbox)
 
 The two red circles clearly indicate that the original circular path has been converted into two circular contours.
 
@@ -1236,7 +1236,7 @@ You've already seen how the `GetFillPath` method of `SKPaint` can convert one pa
 
 One obvious use of `CreateSum` is to define an `SKPaint` object that fills a path with one path effect, and strokes the path with another path effect. This is demonstrated in the **Cats in Frame** sample, which displays an array of cats within a frame with scalloped edges:
 
-[![](effects-images/catsinframe-small.png "Triple screenshot of the Cats In Frame page")](effects-images/catsinframe-large.png#lightbox "Triple screenshot of the Cats In Frame page")
+[![Triple screenshot of the Cats In Frame page](effects-images/catsinframe-small.png)](effects-images/catsinframe-large.png#lightbox)
 
 The [`CatsInFramePage`](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/CatsInFramePage.cs) class begins by defining several fields. You might recognize the first field from the [`PathDataCatPage`](https://github.com/xamarin/xamarin-forms-samples/blob/master/SkiaSharpForms/Demos/Demos/SkiaSharpFormsDemos/Curves/PathDataCatPage.cs) class from the [**SVG Path Data**](~/xamarin-forms/user-interface/graphics/skiasharp/curves/path-data.md) article. The second path is based on a line and arc for the scallop pattern of the frame:
 
@@ -1404,7 +1404,7 @@ public class DashedHatchLinesPage : ContentPage
 
 As you've already discovered, the hatch lines aren't precisely restricted to the interior of the area, and in this example, they always begin at the left with a whole dash:
 
-[![](effects-images/dashedhatchlines-small.png "Triple screenshot of the Dashed Hatch Lines page")](effects-images/dashedhatchlines-large.png#lightbox "Triple screenshot of the Dashed Hatch Lines page")
+[![Triple screenshot of the Dashed Hatch Lines page](effects-images/dashedhatchlines-small.png)](effects-images/dashedhatchlines-large.png#lightbox)
 
 Now that you've seen path effects that range from simple dots and dashes to strange combinations, use your imagination and see what you can create.
 

--- a/docs/xamarin-forms/user-interface/styles/xaml/dynamic.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/dynamic.md
@@ -79,8 +79,8 @@ public partial class DynamicStylesPage : ContentPage
 
 When the `OnButtonClicked` event handler is executed, `searchBarStyle` will switch between `blueSearchBarStyle` and `greenSearchBarStyle`. This results in the appearance shown in the following screenshots:
 
-[![](dynamic-images/dynamic-style-blue.png "Blue Dynamic Style Example")](dynamic-images/dynamic-style-blue-large.png#lightbox "Blue Dynamic Style Example")
-[![](dynamic-images/dynamic-style-green.png "Green Dynamic Style Example")](dynamic-images/dynamic-style-green-large.png#lightbox "Green Dynamic Style Example")
+[![Blue Dynamic Style Example](dynamic-images/dynamic-style-blue.png)](dynamic-images/dynamic-style-blue-large.png#lightbox)
+[![Green Dynamic Style Example](dynamic-images/dynamic-style-green.png)](dynamic-images/dynamic-style-green-large.png#lightbox)
 
 The following code example demonstrates the equivalent page in C#:
 
@@ -158,8 +158,8 @@ The [`SearchBar`](xref:Xamarin.Forms.SearchBar) instances use the `StaticResourc
 
 In the code-behind file, the constructor creates a [`ResourceDictionary`](xref:Xamarin.Forms.ResourceDictionary) entry with the key `searchBarStyle`, as per the previous example that demonstrated dynamic styles. When the `OnButtonClicked` event handler is executed, `searchBarStyle` will switch between `blueSearchBarStyle` and `greenSearchBarStyle`. This results in the appearance shown in the following screenshots:
 
-[![](dynamic-images/dynamic-style-inheritance-blue.png "Blue Dynamic Style Inheritance Example")](dynamic-images/dynamic-style-inheritance-blue-large.png#lightbox "Blue Dynamic Style Inheritance Example")
-[![](dynamic-images/dynamic-style-inheritance-green.png "Green Dynamic Style Inheritance Example")](dynamic-images/dynamic-style-inheritance-green-large.png#lightbox "Green Dynamic Style Inheritance Example")
+[![Blue Dynamic Style Inheritance Example](dynamic-images/dynamic-style-inheritance-blue.png)](dynamic-images/dynamic-style-inheritance-blue-large.png#lightbox)
+[![Green Dynamic Style Inheritance Example](dynamic-images/dynamic-style-inheritance-green.png)](dynamic-images/dynamic-style-inheritance-green-large.png#lightbox)
 
 The following code example demonstrates the equivalent page in C#:
 

--- a/docs/xamarin-forms/user-interface/styles/xaml/explicit.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/explicit.md
@@ -61,7 +61,7 @@ The following code example shows *explicit* styles declared in XAML in a page's 
 
 The [`ResourceDictionary`](xref:Xamarin.Forms.ResourceDictionary) defines three *explicit* styles that are applied to the page's [`Label`](xref:Xamarin.Forms.Label) instances. Each `Style` is used to display text in a different color, while also setting the font size and horizontal and vertical layout options. Each `Style` is applied to a different `Label` by setting its [`Style`](xref:Xamarin.Forms.NavigableElement.Style) properties using the `StaticResource` markup extension. This results in the appearance shown in the following screenshots:
 
-[![](explicit-images/explicit-styles.png "Explicit Styles Example")](explicit-images/explicit-styles-large.png#lightbox "Explicit Styles Example")
+[![Explicit Styles Example](explicit-images/explicit-styles.png)](explicit-images/explicit-styles-large.png#lightbox)
 
 In addition, the final [`Label`](xref:Xamarin.Forms.Label) has a [`Style`](xref:Xamarin.Forms.Style) applied to it, but also overrides the [`TextColor`](xref:Xamarin.Forms.Label.TextColor) property to a different `Color` value.
 

--- a/docs/xamarin-forms/user-interface/styles/xaml/implicit.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/implicit.md
@@ -48,7 +48,7 @@ The following code example shows an *implicit* style declared in XAML in a page'
 
 The [`ResourceDictionary`](xref:Xamarin.Forms.ResourceDictionary) defines a single *implicit* style that's applied to the page's [`Entry`](xref:Xamarin.Forms.Entry) instances. The `Style` is used to display blue text on a yellow background, while also setting other appearance options. The `Style` is added to the page's [`ResourceDictionary`](xref:Xamarin.Forms.ResourceDictionary) without specifying an `x:Key` attribute. Therefore, the `Style` is applied to all the `Entry` instances implicitly as they match the [`TargetType`](xref:Xamarin.Forms.Style.TargetType) property of the `Style` exactly. However, the `Style` is not applied to the `CustomEntry` instance, which is a subclassed `Entry`. This results in the appearance shown in the following screenshots:
 
-[![](implicit-images/implicit-styles.png "Implicit Styles Example")](implicit-images/implicit-styles-large.png#lightbox "Implicit Styles Example")
+[![Implicit Styles Example](implicit-images/implicit-styles.png)](implicit-images/implicit-styles-large.png#lightbox)
 
 In addition, the fourth [`Entry`](xref:Xamarin.Forms.Entry) overrides the [`BackgroundColor`](xref:Xamarin.Forms.VisualElement.BackgroundColor) and [`TextColor`](xref:Xamarin.Forms.Entry.TextColor) properties of the implicit style to different `Color` values.
 

--- a/docs/xamarin-forms/user-interface/styles/xaml/introduction.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/introduction.md
@@ -79,7 +79,7 @@ public class NoStylesPageCS : ContentPage
 
 Each [`Label`](xref:Xamarin.Forms.Label) instance has identical property values for controlling the appearance of the text displayed by the `Label`. This results in the appearance shown in the following screenshots:
 
-[![](introduction-images/no-styles.png "Label Appearance without Styles")](introduction-images/no-styles-large.png#lightbox "Label Appearance without Styles")
+[![Label Appearance without Styles](introduction-images/no-styles.png)](introduction-images/no-styles-large.png#lightbox)
 
 Setting the appearance of each individual control can be repetitive and error prone. Instead, a style can be created that defines the appearance, and then applied to the required controls.
 

--- a/docs/xamarin-forms/user-interface/styles/xaml/style-class.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/style-class.md
@@ -198,7 +198,7 @@ The following example shows three [`BoxView`](xref:Xamarin.Forms.BoxView) instan
 
 In this example, the first [`BoxView`](xref:Xamarin.Forms.BoxView) is styled to be a line separator, while the third `BoxView` is circular. The second `BoxView` has two style classes applied to it, which give it rounded corners and rotate it 45 degrees:
 
-![](style-class-images/boxviews.png "BoxViews styled with style classes")
+![BoxViews styled with style classes](style-class-images/boxviews.png)
 
 > [!IMPORTANT]
 > Multiple style classes can be applied to a control because the [`StyleClass`](xref:Xamarin.Forms.NavigableElement.StyleClass) property is of type `IList<string>`. When this occurs, style classes are applied in ascending list order. Therefore, when multiple style classes set identical properties, the property in the style class that's in the highest list position will take precedence.

--- a/docs/xamarin-forms/user-interface/tableview.md
+++ b/docs/xamarin-forms/user-interface/tableview.md
@@ -15,7 +15,7 @@ ms.date: 12/14/2018
 
 [`TableView`](xref:Xamarin.Forms.TableView) is a view for displaying scrollable lists of data or choices where there are rows that don't share the same template. Unlike [ListView](~/xamarin-forms/user-interface/listview/index.md), `TableView` does not have the concept of an `ItemsSource`, so items must be manually added as children.
 
-![](tableview-images/tableview-all-sml.png "TableView Example")
+![TableView Example](tableview-images/tableview-all-sml.png)
 
 <a name="Use_Cases" />
 
@@ -101,7 +101,7 @@ All of these properties are bindable.
 
 [`SwitchCell`](xref:Xamarin.Forms.SwitchCell) also exposes the `OnChanged` event, allowing you to respond to changes in the cell's state.
 
-![](tableview-images/switch-cell.png "SwitchCell Example")
+![SwitchCell Example](tableview-images/switch-cell.png)
 
 <a name="entrycell" />
 
@@ -118,7 +118,7 @@ All of these properties are bindable.
 
 [`EntryCell`](xref:Xamarin.Forms.EntryCell) also exposes the `Completed` event, which is fired when the user hits the 'done' button on the keyboard while editing text.
 
-![](tableview-images/entry-cell.png "EntryCell Example")
+![EntryCell Example](tableview-images/entry-cell.png)
 
 <a name="Custom_Cells" />
 
@@ -130,7 +130,7 @@ All custom cells must derive from [`ViewCell`](xref:Xamarin.Forms.ViewCell), the
 
 This is an example of a custom cell:
 
-![](tableview-images/custom-cell.png "Custom Cell Example")
+![Custom Cell Example](tableview-images/custom-cell.png)
 
 The following example shows the XAML used to create the [`TableView`](xref:Xamarin.Forms.TableView) in the screenshots above:
 
@@ -247,11 +247,11 @@ The `OnViewCellTapped` event handler shows or hides the second [`Label`](xref:Xa
 
 The following screenshots show the cell prior to being tapped upon:
 
-![](tableview-images/cell-beforeresize.png "ViewCell before being resized")
+![ViewCell before being resized](tableview-images/cell-beforeresize.png)
 
 The following screenshots show the cell after being tapped upon:
 
-![](tableview-images/cell-afterresize.png "ViewCell after being resized")
+![ViewCell after being resized](tableview-images/cell-afterresize.png)
 
 > [!IMPORTANT]
 > There is a strong possibility of performance degradation if this feature is overused.

--- a/docs/xamarin-forms/user-interface/text/entry.md
+++ b/docs/xamarin-forms/user-interface/text/entry.md
@@ -100,7 +100,7 @@ In C#:
 var MyEntry = new Entry { IsPassword = true };
 ```
 
-![](entry-images/password.png "Entry IsPassword Example")
+![Entry IsPassword Example](entry-images/password.png)
 
 Placeholders may be used with instances of `Entry` that are configured as password fields:
 
@@ -116,7 +116,7 @@ In C#:
 var MyEntry = new Entry { IsPassword = true, Placeholder = "Password" };
 ```
 
-![](entry-images/passwordplaceholder.png "Entry IsPassword and Placeholder Example")
+![Entry IsPassword and Placeholder Example](entry-images/passwordplaceholder.png)
 
 ### Setting the Cursor Position and Text Selection Length
 
@@ -289,7 +289,7 @@ var entry = new Entry();
 entry.TextColor = Color.Green;
 ```
 
-![](entry-images/textcolor.png "Entry TextColor Example")
+![Entry TextColor Example](entry-images/textcolor.png)
 
 Note that the placeholder is not affected by the specified `TextColor`.
 
@@ -306,7 +306,7 @@ var entry = new Entry();
 entry.BackgroundColor = Color.FromHex("#2c3e50");
 ```
 
-![](entry-images/textbackgroundcolor.png "Entry BackgroundColor Example")
+![Entry BackgroundColor Example](entry-images/textbackgroundcolor.png)
 
 Be careful to make sure that the background and text colors you choose are usable on each platform and don't obscure any placeholder text.
 

--- a/docs/xamarin-forms/user-interface/text/index.md
+++ b/docs/xamarin-forms/user-interface/text/index.md
@@ -29,7 +29,7 @@ Text appearance can be changed using built-in or custom [styles](#Styles) and so
 
 The `Label` view is used to display text. It can show multiple lines of text or a single line of text. `Label` can present text with multiple formatting options used in inline. The label view can wrap or truncate text when it can't fit on one line.
 
-![](images/label.png "Label Example")
+![Label Example](images/label.png)
 
 See the [Label](label.md) article for more detailed information.
 
@@ -41,7 +41,7 @@ For information on customizing the font used in a label, see [Fonts](fonts.md).
 
 `Entry` is used to accept single-line text input. `Entry` offers control over colors and fonts. `Entry` has a password mode and can show placeholder text until text is entered.
 
-![](images/entry.png "Entry Example")
+![Entry Example](images/entry.png)
 
 See the [Entry](entry.md) article for more information.
 
@@ -53,7 +53,7 @@ Note that, unlike `Label`, `Entry` cannot have custom font settings.
 
 `Editor` is used to accept multi-line text input. `Editor` offers control over colors and fonts.
 
-![](images/editor.png "Editor Example")
+![Editor Example](images/editor.png)
 
 See the [Editor](editor.md) article for more information.
 

--- a/docs/xamarin-forms/user-interface/text/label.md
+++ b/docs/xamarin-forms/user-interface/text/label.md
@@ -43,7 +43,7 @@ var bothLabel = new Label { Text = "This is underlined text with strikethrough."
 
 The following screenshots show the `TextDecorations` enumeration members applied to [`Label`](xref:Xamarin.Forms.Label) instances:
 
-![](label-images/label-textdecorations.png "Labels with Text Decorations")
+![Labels with Text Decorations](label-images/label-textdecorations.png)
 
 > [!NOTE]
 > Text decorations can also be applied to [`Span`](xref:Xamarin.Forms.Span) instances. For more information about the `Span` class, see [Formatted Text](#Formatted_Text).
@@ -86,7 +86,7 @@ public partial class LabelPage : ContentPage
 
 The following screenshots show the result of setting the `TextColor` property:
 
-![](label-images/textcolor.png "Label TextColor Example")
+![Label TextColor Example](label-images/textcolor.png)
 
 For more information about colors, see [Colors](~/xamarin-forms/user-interface/colors.md).
 
@@ -135,7 +135,7 @@ var label =
 
 The following screenshots show the result of setting the `MaxLines` property to 2, when the text is long enough to occupy more than 2 lines:
 
-![](label-images/label-maxlines.png "Label MaxLines Example")
+![Label MaxLines Example](label-images/label-maxlines.png)
 
 <a name="Formatted_Text" />
 
@@ -218,7 +218,7 @@ Note that a [`Span`](xref:Xamarin.Forms.Span) can also respond to any gestures t
 
 The following screenshots show the result of setting the `FormattedString` property to three `Span` instances:
 
-![](label-images/formattedtext.png "Label FormattedText Example")
+![Label FormattedText Example](label-images/formattedtext.png)
 
 ## Line height
 
@@ -249,7 +249,7 @@ var label =
 
 The following screenshots show the result of setting the [`Label.LineHeight`](xref:Xamarin.Forms.Label.LineHeight) property to 1.8:
 
-![](label-images/label-lineheight.png "Label LineHeight Example")
+![Label LineHeight Example](label-images/label-lineheight.png)
 
 The following XAML example demonstrates setting the [`LineHeight`](xref:Xamarin.Forms.Span.LineHeight) property on a [`Span`](xref:Xamarin.Forms.Span):
 
@@ -289,7 +289,7 @@ var label = new Label
 
 The following screenshots show the result of setting the [`Span.LineHeight`](xref:Xamarin.Forms.Span.LineHeight) property to 1.8:
 
-![](label-images/span-lineheight.png "Span LineHeight Example")
+![Span LineHeight Example](label-images/span-lineheight.png)
 
 ## Hyperlinks
 

--- a/docs/xamarin-forms/user-interface/text/styles.md
+++ b/docs/xamarin-forms/user-interface/text/styles.md
@@ -43,7 +43,7 @@ In C#, built-in styles are selected from `Device.Styles`:
 label.Style = Device.Styles.TitleStyle;
 ```
 
-![](styles-images/builtinstyles.png "Device Styles Example")
+![Device Styles Example](styles-images/builtinstyles.png)
 
 <a name="Custom_Styles" />
 
@@ -85,7 +85,7 @@ In XAML:
 
 Note that resources (including all styles) are defined within `ContentPage.Resources`, which is a sibling of the more familiar `ContentPage.Content` element.
 
-![](styles-images/customstyle.png "Custom Styles Example")
+![Custom Styles Example](styles-images/customstyle.png)
 
 <a name="Applying_Styles" />
 
@@ -132,11 +132,11 @@ Consider the following example of the same page of views styled with the built-i
 
 Disabled:
 
-![](styles-images/pre-access.png "Device Styles with Accessibility Disabled")
+![Device Styles with Accessibility Disabled](styles-images/pre-access.png)
 
 Enabled:
 
-![](styles-images/post-access.png "Device Styles with Accessibility Enabled")
+![Device Styles with Accessibility Enabled](styles-images/post-access.png)
 
 To ensure accessibility, make sure that built-in styles are used as the basis for any text-related styles within your app, and that you are using styles consistently. See [Styles](~/xamarin-forms/user-interface/styles/index.md) for more details on extending and working with styles in general.
 

--- a/docs/xamarin-forms/user-interface/webview.md
+++ b/docs/xamarin-forms/user-interface/webview.md
@@ -15,7 +15,7 @@ ms.date: 07/19/2019
 
 [`WebView`](xref:Xamarin.Forms.WebView) is a view for displaying web and HTML content in your app. Unlike `OpenUri`, which takes the user to the web browser on the device, `WebView` displays the HTML content inside your app.
 
-![](webview-images/in-app-browser.png "In App Browser")
+![In App Browser](webview-images/in-app-browser.png)
 
 ## Content
 
@@ -100,7 +100,7 @@ htmlSource.Html = @"<html><body>
 browser.Source = htmlSource;
 ```
 
-![](webview-images/html-string.png "WebView Displaying HTML String")
+![WebView Displaying HTML String](webview-images/html-string.png)
 
 In the above code, `@` is used to mark the HTML as a string literal, meaning all the usual escape characters are ignored.
 
@@ -142,7 +142,7 @@ To display local content using a `WebView`, you'll need to open the HTML file li
 
 The following screenshots show the result of displaying local content on each platform:
 
-![](webview-images/local-content.png "WebView Displaying Local Content")
+![WebView Displaying Local Content](webview-images/local-content.png)
 
 Although the first page has been loaded, the `WebView` has no knowledge of where the HTML came from. That is a problem when dealing with pages that reference local resources. Examples of when that might happen include when local pages link to each other, a page makes use of a separate JavaScript file, or a page links to a CSS stylesheet.  
 
@@ -171,11 +171,11 @@ On iOS, the web content should be located in the project's root directory or **R
 
 # [Visual Studio](#tab/windows)
 
-![](webview-images/ios-vs.png "Local Files on iOS")
+![Local Files on iOS](webview-images/ios-vs.png)
 
 # [Visual Studio for Mac](#tab/macos)
 
-![](webview-images/ios-xs.png "Local Files on iOS")
+![Local Files on iOS](webview-images/ios-xs.png)
 
 -----
 
@@ -201,11 +201,11 @@ On Android, place HTML, CSS, and images in the Assets folder with build action *
 
 # [Visual Studio](#tab/windows)
 
-![](webview-images/android-vs.png "Local Files on Android")
+![Local Files on Android](webview-images/android-vs.png)
 
 # [Visual Studio for Mac](#tab/macos)
 
-![](webview-images/android-xs.png "Local Files on Android")
+![Local Files on Android](webview-images/android-xs.png)
 
 -----
 
@@ -323,7 +323,7 @@ public partial class InAppBrowserXaml : ContentPage
 
 That's it!
 
-![](webview-images/in-app-browser.png "WebView Navigation Buttons")
+![WebView Navigation Buttons](webview-images/in-app-browser.png)
 
 ## Events
 
@@ -378,11 +378,11 @@ void webviewNavigated(object sender, WebNavigatedEventArgs e)
 
 This results in the following output (loading):
 
-![](webview-images/loading-start.png "WebView Navigating Event Example")
+![WebView Navigating Event Example](webview-images/loading-start.png)
 
 Finished Loading:
 
-![](webview-images/loading-end.png "WebView Navigated Event Example")
+![WebView Navigating Event Example](webview-images/loading-end.png)
 
 ## Reloading content
 

--- a/docs/xamarin-forms/xaml/passing-arguments.md
+++ b/docs/xamarin-forms/xaml/passing-arguments.md
@@ -86,7 +86,7 @@ The number of elements within the `x:Arguments` tag, and the types of these elem
 
 The following screenshots show the result of calling each [`Color`](xref:Xamarin.Forms.Color) constructor with the specified argument values:
 
-![](passing-arguments-images/passing-arguments.png "BoxView.Color specified with x:Arguments")
+![BoxView.Color specified with x:Arguments](passing-arguments-images/passing-arguments.png)
 
 <a name="factory_methods" />
 
@@ -136,7 +136,7 @@ The number of elements within the `x:Arguments` tag, and the types of these elem
 
 The following screenshots show the result of calling each [`Color`](xref:Xamarin.Forms.Color) factory method with the specified argument values:
 
-![](passing-arguments-images/factory-methods.png "BoxView.Color specified with x:FactoryMethod and x:Arguments")
+![BoxView.Color specified with x:FactoryMethod and x:Arguments](passing-arguments-images/factory-methods.png)
 
 <a name="generic_type_arguments" />
 

--- a/docs/xamarin-forms/xaml/resource-dictionaries.md
+++ b/docs/xamarin-forms/xaml/resource-dictionaries.md
@@ -102,7 +102,7 @@ Each resource has a key that is specified using the `x:Key` attribute, which bec
 
 The first [`Label`](xref:Xamarin.Forms.Label) instance retrieves and consumes the `LabelPageHeadingStyle` resource defined in the application level `ResourceDictionary`, with the second `Label` instance retrieving and consuming the `LabelNormalStyle` resource defined in the control level `ResourceDictionary`. Similarly, the [`Button`](xref:Xamarin.Forms.Button) instance retrieves and consumes the `NormalTextColor` resource defined in the application level `ResourceDictionary`, and the `MediumBoldText` resource defined in the control level `ResourceDictionary`. This results in the appearance shown in the following screenshots:
 
-[![](resource-dictionaries-images/screenshots-sml.png "Consuming ResourceDictionary Resources")](resource-dictionaries-images/screenshots.png#lightbox "Consuming ResourceDictionary Resources")
+[![Consuming ResourceDictionary Resources](resource-dictionaries-images/screenshots-sml.png)](resource-dictionaries-images/screenshots.png#lightbox)
 
 > [!NOTE]
 > Resources that are specific to a single page shouldn't be included in an application level resource dictionary, as such resources will then be parsed at application startup instead of when required by a page. For more information, see [Reduce the Application Resource Dictionary Size](~/xamarin-forms/deploy-test/performance.md).
@@ -137,7 +137,7 @@ When `ResourceDictionary` resources share `x:Key` attribute values, resources de
 
 The original `PageBackgroundColor` and `NormalTextColor` instances, defined at the application level, are overridden by the `PageBackgroundColor` and `NormalTextColor` instances defined at page level. Therefore, the page background color becomes blue, and the text on the page becomes yellow, as demonstrated in the following screenshots:
 
-[![](resource-dictionaries-images/overridding-screenshots-sml.png "Overriding ResourceDictionary Resources")](resource-dictionaries-images/overridding-screenshots.png#lightbox "Overriding ResourceDictionary Resources")
+[![Overriding ResourceDictionary Resources](resource-dictionaries-images/overridding-screenshots-sml.png)](resource-dictionaries-images/overridding-screenshots.png#lightbox)
 
 However, note that the background bar of the [`NavigationPage`](xref:Xamarin.Forms.NavigationPage) is still yellow, because the  [`BarBackgroundColor`](xref:Xamarin.Forms.NavigationPage.BarBackgroundColor) property is set to the value of the `PageBackgroundColor` resource defined in the application level `ResourceDictionary`.
 

--- a/docs/xamarin-forms/xaml/xaml-basics/data-binding-basics.md
+++ b/docs/xamarin-forms/xaml/xaml-basics/data-binding-basics.md
@@ -97,7 +97,7 @@ Text="{Binding Value, StringFormat='The angle is {0:F0} degrees'}"
 
 Here’s the running program:
 
-[![](data-binding-basics-images/sliderbinding.png "View-to-View Bindings")](data-binding-basics-images/sliderbinding-large.png#lightbox "View-to-View Bindings ")
+[![View-to-View Bindings](data-binding-basics-images/sliderbinding.png)](data-binding-basics-images/sliderbinding-large.png#lightbox)
 
 ## The Binding Mode
 
@@ -196,7 +196,7 @@ The bindings on three of the `Slider` views are `OneWayToSource`, meaning that t
 
 However, the binding for the `Scale` property is `TwoWay`. This is because the `Scale` property has a default value of 1, and using a `TwoWay` binding causes the `Slider` initial value to be set at 1 rather than 0. If that binding were `OneWayToSource`, the `Scale` property would initially be set to 0 from the `Slider` default value. The `Label` would not be visible, and that might cause some confusion to the user.
 
- [![](data-binding-basics-images/slidertransforms.png "Backwards Bindings")](data-binding-basics-images/slidertransforms-large.png#lightbox "Backwards Bindings")
+ [![Backwards Bindings](data-binding-basics-images/slidertransforms.png)](data-binding-basics-images/slidertransforms-large.png#lightbox)
 
  > [!NOTE]
  > The [`VisualElement`](xref:Xamarin.Forms.VisualElement) class also has [`ScaleX`](xref:Xamarin.Forms.VisualElement.ScaleX) and [`ScaleY`](xref:Xamarin.Forms.VisualElement.ScaleY) properties, which scale the `VisualElement` on the x-axis and y-axis respectively.
@@ -229,7 +229,7 @@ Setting the static `NamedColor.All` property to the `ItemsSource` of a `ListView
 
 The resultant display establishes that the items are truly of type `XamlSamples.NamedColor`:
 
-[![](data-binding-basics-images/listview1.png "Binding to a Collection")](data-binding-basics-images/listview1-large.png#lightbox "Binding to a Collection")
+[![Binding to a Collection](data-binding-basics-images/listview1.png)](data-binding-basics-images/listview1-large.png#lightbox)
 
 It’s not much information, but the `ListView` is scrollable and selectable.
 
@@ -254,7 +254,7 @@ To define a template for the items, you’ll want to break out the `ItemTemplate
 
 The `Label` element is set to the `View` property of the `ViewCell`. (The `ViewCell.View` tags are not needed because the `View` property is the content property of `ViewCell`.) This markup displays the `FriendlyName` property of each `NamedColor` object:
 
-[![](data-binding-basics-images/listview2.png "Binding to a Collection with a DataTemplate")](data-binding-basics-images/listview2-large.png#lightbox "Binding to a Collection with a DataTemplate")
+[![Binding to a Collection with a DataTemplate](data-binding-basics-images/listview2.png)](data-binding-basics-images/listview2-large.png#lightbox)
 
 Much better. Now all that’s needed is to spruce up the item template with more information and the actual color. To support this template, some values and objects have been defined in the page’s resource dictionary:
 
@@ -391,7 +391,7 @@ Three data bindings reference this single instance. Notice that the `Binding` ma
 
 Here’s the result:
 
-[![](data-binding-basics-images/listview3.png "Binding to a Collection with a DataTemplate and Converters")](data-binding-basics-images/listview3-large.png#lightbox "Binding to a Collection with a DataTemplate and Converters")
+[![Binding to a Collection with a DataTemplate and Converters](data-binding-basics-images/listview3.png)](data-binding-basics-images/listview3-large.png#lightbox)
 
 The `ListView` is quite sophisticated in handling changes that might dynamically occur in the underlying data, but only if you take certain steps. If the collection of items assigned to the `ItemsSource` property of the `ListView` changes during runtime—that is, if items can be added to or removed from the collection—use an `ObservableCollection` class for these items. `ObservableCollection` implements the `INotifyCollectionChanged` interface, and `ListView` will install a handler for the `CollectionChanged` event.
 

--- a/docs/xamarin-forms/xaml/xaml-basics/essential-xaml-syntax.md
+++ b/docs/xamarin-forms/xaml/xaml-basics/essential-xaml-syntax.md
@@ -250,7 +250,7 @@ The `Grid.Row` and `Grid.Column` settings of 0 are not required but are generall
 
 Here’s what it looks like:
 
-[![](essential-xaml-syntax-images/griddemo.png "Grid Layout")](essential-xaml-syntax-images/griddemo-large.png#lightbox "Grid Layout")
+[![Grid Layout](essential-xaml-syntax-images/griddemo.png)](essential-xaml-syntax-images/griddemo-large.png#lightbox)
 
 Judging solely from the syntax, these `Grid.Row`, `Grid.Column`, `Grid.RowSpan`, and `Grid.ColumnSpan` attributes appear to be static fields or properties of `Grid`, but interestingly enough, `Grid` does not define anything named `Row`, `Column`, `RowSpan`, or `ColumnSpan`.
 
@@ -307,7 +307,7 @@ The `AbsoluteLayout` class defines two attached properties named `LayoutBounds` 
 
 And here it is:
 
-[![](essential-xaml-syntax-images/absolutedemo-large.png "Absolute Layout")](essential-xaml-syntax-images/absolutedemo-large.png#lightbox "Absolute Layout")
+[![Absolute Layout](essential-xaml-syntax-images/absolutedemo-large.png)](essential-xaml-syntax-images/absolutedemo-large.png#lightbox)
 
 For something like this, you might question the wisdom of using XAML. Certainly, the repetition and regularity of the `LayoutBounds` rectangle suggests that it might be better realized in code.
 

--- a/docs/xamarin-forms/xaml/xaml-basics/get-started-with-xaml.md
+++ b/docs/xamarin-forms/xaml/xaml-basics/get-started-with-xaml.md
@@ -25,13 +25,13 @@ To begin editing your first XAML file, use Visual Studio or Visual Studio for Ma
 
 In Windows, use Visual Studio to select **File > New > Project** from the menu. In the **New Project** dialog, select **Visual C# > Cross Platform** at the left, and then **Mobile App (Xamarin.Forms)** from the list in the center.
 
-![](get-started-with-xaml-images/win/newprojectdialog.w157.png "New Project Dialog")
+![New Project Dialog](get-started-with-xaml-images/win/newprojectdialog.w157.png)
 
 Select a location for the solution, give it a name of **XamlSamples** (or whatever you prefer), and press **OK**.
 
 On the next screen, select the **Blank App** template and the **.NET Standard** code-sharing strategy:
 
-![](get-started-with-xaml-images/win/newcrossplatformapp.png "New App Dialog")
+![New App Dialog](get-started-with-xaml-images/win/newcrossplatformapp.png)
 
 Press **OK**.
 
@@ -41,19 +41,19 @@ Four projects are created in the solution: the **XamlSamples** .NET Standard lib
 
 In Visual Studio for Mac, select **File > New Solution** from the menu. In the **New Project** dialog, select **Multiplatform > App** at the left, and **Blank Forms App** (*not* **Forms App**) from the template list:
 
-![](get-started-with-xaml-images/mac/newprojectdialog1.png "New Project Dialog 1")
+![New Project Dialog 1](get-started-with-xaml-images/mac/newprojectdialog1.png)
 
 Press **Next**.
 
 In the next dialog, give the project a name of **XamlSamples** (or whatever you prefer). Make sure that the **Use .NET Standard** radio button is selected:
 
-![](get-started-with-xaml-images/mac/newprojectdialog2.png "New Project Dialog 2")
+![New Project Dialog 2](get-started-with-xaml-images/mac/newprojectdialog2.png)
 
 Press **Next**.
 
 In the following dialog, you can select a location for the project:
 
-![](get-started-with-xaml-images/mac/newprojectdialog3.png "New Project Dialog 3")
+![New Project Dialog 3](get-started-with-xaml-images/mac/newprojectdialog3.png)
 
 Press **Create**
 
@@ -136,7 +136,7 @@ Although you normally don’t need to spend much time with generated code files,
 
 When you compile and run this program, the `Label` element appears in the center of the page as the XAML suggests:
 
-[![](get-started-with-xaml-images/xamlsamples.png "Default Xamarin.Forms display")](get-started-with-xaml-images/xamlsamples-large.png#lightbox "Default Xamarin.Forms display")
+[![Default Xamarin.Forms display](get-started-with-xaml-images/xamlsamples.png)](get-started-with-xaml-images/xamlsamples-large.png#lightbox)
 
 For more interesting visuals, all you need is more interesting XAML.
 
@@ -146,13 +146,13 @@ For more interesting visuals, all you need is more interesting XAML.
 
 To add other XAML-based `ContentPage` classes to your project, select the **XamlSamples** .NET Standard library project and invoke the **Project > Add New Item** menu item. At the left of the **Add New Item** dialog, select **Visual C#** and **Xamarin.Forms**. From the list select **Content Page** (not **Content Page (C#)**, which creates a code-only page, or **Content View**, which is not a page). Give the page a name, for example, **HelloXamlPage.xaml**:
 
-![](get-started-with-xaml-images/win/addnewitemdialog.w157.png "Add New Item Dialog")
+![Add New Item Dialog](get-started-with-xaml-images/win/addnewitemdialog.w157.png)
 
 # [Visual Studio for Mac](#tab/macos)
 
 To add other XAML-based `ContentPage` classes to your project, select the **XamlSamples** .NET Standard library project and invoke the **File > New File** menu item. At the left of the **New File** dialog, select **Forms** at the left, and **Forms ContentPage Xaml** (not **Forms ContentPage**, which creates a code-only page, or **Content View**, which is not a page). Give the page a name, for example, **HelloXamlPage**:
 
-![](get-started-with-xaml-images/mac/newfiledialog.png "New File Dialog")
+![New File Dialog](get-started-with-xaml-images/mac/newfiledialog.png)
 
 -----
 
@@ -274,7 +274,7 @@ public MainPage()
 
 Setting the `Content` property of the page replaces the setting of the `Content` property in the XAML file. When you compile and deploy the new version of this program, a button appears on the screen. Pressing it navigates to `HelloXamlPage`. Here’s the resultant page on iPhone, Android, and UWP:
 
-[![](get-started-with-xaml-images/helloxaml1.png "Rotated Label Text")](get-started-with-xaml-images/helloxaml1-large.png#lightbox "Rotated Label Text")
+[![Rotated Label Text](get-started-with-xaml-images/helloxaml1.png)](get-started-with-xaml-images/helloxaml1-large.png#lightbox)
 
 You can navigate back to `MainPage` using the **< Back** button on iOS, using the left arrow at the top of the page or at the bottom of the phone on Android, or using the left arrow at the top of the page on Windows 10.
 
@@ -284,7 +284,7 @@ Feel free to experiment with the XAML for different ways to render the `Label`. 
 
 Here’s what it looks like:
 
-[![](get-started-with-xaml-images/helloxaml2.png "Rotated Label Text with Unicode Characters")](get-started-with-xaml-images/helloxaml2-large.png#lightbox "Rotated Label Text with Unicode Characters")
+[![Rotated Label Text with Unicode Characters](get-started-with-xaml-images/helloxaml2.png)](get-started-with-xaml-images/helloxaml2-large.png#lightbox)
 
 ## XAML and Code Interactions
 
@@ -312,7 +312,7 @@ The **HelloXamlPage** sample contains only a single `Label` on the page, but thi
 
 This XAML file is syntactically complete, and here’s what it looks like:
 
-[![](get-started-with-xaml-images/xamlpluscode1.png "Multiple Controls on a Page")](get-started-with-xaml-images/xamlpluscode1-large.png#lightbox "Multiple Controls on a Page")
+[![Multiple Controls on a Page](get-started-with-xaml-images/xamlpluscode1.png)](get-started-with-xaml-images/xamlpluscode1-large.png#lightbox)
 
 However, you are likely to consider this program to be functionally deficient. Perhaps the `Slider` is supposed to cause the `Label` to display the current value, and the `Button` is probably intended to do something within the program.
 
@@ -403,7 +403,7 @@ void OnSliderValueChanged(object sender, ValueChangedEventArgs args)
 
 When you first run the program, the `Label` doesn’t display the `Slider` value because the `ValueChanged` event hasn’t yet fired. But any manipulation of the `Slider` causes the value to be displayed:
 
-[![](get-started-with-xaml-images/xamlpluscode2.png "Slider Value Displayed")](get-started-with-xaml-images/xamlpluscode2-large.png#lightbox "Slider Value Displayed")
+[![Slider Value Displayed](get-started-with-xaml-images/xamlpluscode2.png)](get-started-with-xaml-images/xamlpluscode2-large.png#lightbox)
 
 Now for the `Button`. Let’s simulate a response to a `Clicked` event by displaying an alert with the `Text` of the button. The event handler can safely cast the `sender` argument to a `Button` and then access its properties:
 

--- a/docs/xamarin-forms/xaml/xaml-basics/xaml-markup-extensions.md
+++ b/docs/xamarin-forms/xaml/xaml-basics/xaml-markup-extensions.md
@@ -296,7 +296,7 @@ Here’s the final complete XAML file with three buttons accessing six shared va
 
 The screenshots verify the consistent styling, and the platform-dependent styling:
 
-[![](xaml-markup-extensions-images/sharedresources.png "Styled Controls")](xaml-markup-extensions-images/sharedresources-large.png#lightbox "Styled Controls")
+[![Styled Controls](xaml-markup-extensions-images/sharedresources.png)](xaml-markup-extensions-images/sharedresources-large.png#lightbox)
 
 Although it is most common to define the `Resources` collection at the top of the page, keep in mind that the `Resources` property is defined by `VisualElement`, and you can have `Resources` collections on other elements on the page. For example, try adding one to the `StackLayout` in this example:
 
@@ -434,7 +434,7 @@ Both these namespace declarations are included in the **StaticConstantsPage** sa
 
 The size of the resultant `BoxView` relative to the screen is platform-dependent:
 
- [![](xaml-markup-extensions-images/staticconstants.png "Controls using x:Static Markup Extension")](xaml-markup-extensions-images/staticconstants-large.png#lightbox "Controls using x:Static Markup Extension")
+[![Controls using x:Static Markup Extension](xaml-markup-extensions-images/staticconstants.png)](xaml-markup-extensions-images/staticconstants-large.png#lightbox)
 
 ## Other Standard Markup Extensions
 
@@ -550,7 +550,7 @@ Perhaps the most important lesson you should take from this sample is the syntax
 
 Here’s the program running:
 
-[![](xaml-markup-extensions-images/relativelayout.png "Relative Layout using Constraints")](xaml-markup-extensions-images/relativelayout-large.png#lightbox "Relative Layout using Constraints")
+[![Relative Layout using Constraints](xaml-markup-extensions-images/relativelayout.png)](xaml-markup-extensions-images/relativelayout-large.png#lightbox)
 
 ## Summary
 


### PR DESCRIPTION

Images should have alternate text.
Many had it in the "title" position instead of alt-text