### PR TITLE
Small grammar change

### DIFF
--- a/docs/cross-platform/app-fundamentals/localization.md
+++ b/docs/cross-platform/app-fundamentals/localization.md
@@ -233,7 +233,7 @@ Use specific strings for each state to provide a better user experience:
 **Good**:
 
 ```csharp
-"You have no message."
+"You have no messages."
 "You have 1 message."
 "You have 2 messages."
 "You have {0} messages."

--- a/docs/cross-platform/app-fundamentals/localization.md
+++ b/docs/cross-platform/app-fundamentals/localization.md
@@ -233,8 +233,8 @@ Use specific strings for each state to provide a better user experience:
 **Good**:
 
 ```csharp
-"You have no messages."
-"You have 1 messages."
+"You have no message."
+"You have 1 message."
 "You have 2 messages."
 "You have {0} messages."
 ```


### PR DESCRIPTION
The typing mistake could make best practices use cases difficult to understand.