### PR TITLE
Updating broken links

### DIFF
--- a/docs/android/index.yml
+++ b/docs/android/index.yml
@@ -60,19 +60,19 @@ sections:
       html: Everything you need to know to build Android apps, such as working with files, images, databases, and more.
       image:
         src: ~/media/icons/i_app-build.svg
-        href: ~/android/app-fundamentals/
+        href: ~/android/app-fundamentals/index.md
       title: Application Fundamentals
     - href: ~/android/user-interface/index.md
       html: Learn about the complete set of user interface control widgets available for Android.
       image:
         src: ~/media/icons/i_user-interface.svg
-        href: ~/android/user-interface/
+        href: ~/android/user-interface/index.md
       title: User Interface
     - href: ~/android/platform/index.md
       html: Working with Android platform features, such as fingerprint authentication, and the newest features in Android 8.0 Oreo.
       image:
         src: ~/media/icons/i_platform.svg
-        href: ~/android/platform/
+        href: ~/android/platform/index.md
       title: Platform Features
     - href: ~/essentials/index.md?context=xamarin/android
       html: Cross-platform APIs for mobile applications.
@@ -84,25 +84,25 @@ sections:
       html: Local and remote data storage and retrieval, and other cloud-based services.
       image:
         src: ~/media/icons/i_data-cloud.svg
-        href: ~/android/data-cloud/
+        href: ~/android/data-cloud/index.md
       title: Data & Cloud Services
     - href: ~/android/deploy-test/index.md
       html: Instructions for building and deploying your apps to Google Play, and tips for testing them beforehand!
       image:
         src: ~/media/icons/i_deploy-test.svg
-        href: ~/android/deploy-test/
+        href: ~/android/deploy-test/index.md
       title: Deployment and Testing
     - href: ~/android/internals/index.md
       html: Additional information about Xamarin.Android internals and assistance with features like localization and accessibility.
       image:
         src: https://docs.microsoft.com/media/common/i_advanced.svg
-        href: ~/android/internals/
+        href: ~/android/internals/index.md
       title: Advanced Concepts & Internals
     - href: ~/android/wear/index.md
       html: Building apps for Android Wear.
       image:
         src: ~/media/icons/i_android-wear.svg
-        href: ~/android/wear/
+        href: ~/android/wear/index.md
       title: Android Wear
 - title: Reference
   items:

--- a/docs/android/index.yml
+++ b/docs/android/index.yml
@@ -56,19 +56,19 @@ sections:
         src: https://docs.microsoft.com/media/common/i_get-started.svg
         href: ~/android/get-started/index.md
       title: Getting Started
-    - href: ~/android/app-fundamentals/
+    - href: ~/android/app-fundamentals/index.md
       html: Everything you need to know to build Android apps, such as working with files, images, databases, and more.
       image:
         src: ~/media/icons/i_app-build.svg
         href: ~/android/app-fundamentals/
       title: Application Fundamentals
-    - href: ~/android/user-interface
+    - href: ~/android/user-interface/index.md
       html: Learn about the complete set of user interface control widgets available for Android.
       image:
         src: ~/media/icons/i_user-interface.svg
         href: ~/android/user-interface/
       title: User Interface
-    - href: ~/android/platform/
+    - href: ~/android/platform/index.md
       html: Working with Android platform features, such as fingerprint authentication, and the newest features in Android 8.0 Oreo.
       image:
         src: ~/media/icons/i_platform.svg
@@ -80,25 +80,25 @@ sections:
         src: https://docs.microsoft.com/media/common/i_multi-connect.svg
         href: ~/essentials/index.md?context=xamarin/android
       title: Xamarin.Essentials
-    - href: ~/android/data-cloud/
+    - href: ~/android/data-cloud/index.md
       html: Local and remote data storage and retrieval, and other cloud-based services.
       image:
         src: ~/media/icons/i_data-cloud.svg
         href: ~/android/data-cloud/
       title: Data & Cloud Services
-    - href: ~/android/deploy-test/
+    - href: ~/android/deploy-test/index.md
       html: Instructions for building and deploying your apps to Google Play, and tips for testing them beforehand!
       image:
         src: ~/media/icons/i_deploy-test.svg
         href: ~/android/deploy-test/
       title: Deployment and Testing
-    - href: ~/android/internals/
+    - href: ~/android/internals/index.md
       html: Additional information about Xamarin.Android internals and assistance with features like localization and accessibility.
       image:
         src: https://docs.microsoft.com/media/common/i_advanced.svg
         href: ~/android/internals/
       title: Advanced Concepts & Internals
-    - href: ~/android/wear/
+    - href: ~/android/wear/index.md
       html: Building apps for Android Wear.
       image:
         src: ~/media/icons/i_android-wear.svg


### PR DESCRIPTION
Updating broken links under guide section, to point to right index.md.

URL: https://docs.microsoft.com/en-us/xamarin/android/index?WT.mc_id=docs-dotnet-xamarin

Check links under guides are broken