### PR TITLE
chore: Enable MD033 for tables

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -17,7 +17,6 @@
       "sup", "sub",
       "h3", "h4",
       "pre",
-      "table", "td", "tr", "th",
       "br",
       "kbd",
       "dl", "dt", "dd",


### PR DESCRIPTION

Looks like all the table HTML has been converted to Markdown