### PR TITLE
MS Mobile OpenJDK is not in preview anymore

### DIFF
--- a/docs/android/get-started/installation/android-sdk.md
+++ b/docs/android/get-started/installation/android-sdk.md
@@ -55,7 +55,7 @@ several JDK alternatives to choose from:
     if you are developing specifically for API level 23 or earlier.
 
 - If you are using Visual Studio 15.8 Preview 5 or later, you can try
-    using [Microsoft's Mobile OpenJDK Distribution](openjdk.md) (currently in preview) 
+    using [Microsoft's Mobile OpenJDK Distribution](openjdk.md) 
     rather than JDK 8.
 
 > [!IMPORTANT]
@@ -211,7 +211,7 @@ several JDK alternatives to choose from:
     if you are developing specifically for API level 23 or earlier.
 
 - If you are using Visual Studio for Mac 7.7 or later, you can try
-    using [Microsoft's Mobile OpenJDK Distribution](openjdk.md) (currently in preview) 
+    using [Microsoft's Mobile OpenJDK Distribution](openjdk.md)
     rather than JDK 8.
 
 > [!IMPORTANT]


### PR DESCRIPTION
Removed the mentions of Microsoft's Mobile OpenJDK Distribution being currently in preview, since that hasn't been the case since late last year.