### PR TITLE
Fixed wrong code block language tags

### DIFF
--- a/docs/ios/platform/passkit.md
+++ b/docs/ios/platform/passkit.md
@@ -128,7 +128,7 @@ pieces of information in every pass are:
 There is a large number of other JSON keys in each Pass, an example of which
 is shown below:
 
-``` 
+```
 {
    "passTypeIdentifier":"com.xamarin.passkitdoc.banana",  //Type Identifier (iOS Provisioning Portal)
    "formatVersion":1,                                     //Always 1 (for now)
@@ -317,7 +317,7 @@ present:
 Open pass.json and edit the JSON. You must at least update the `passTypeIdentifier` and `teamIdentifer` to match your
 Apple Developer account.
 
-```csharp
+```json
 "passTypeIdentifier" : "pass.com.xamarin.coupon.banana",
 "teamIdentifier" : "?????????",
 ```
@@ -325,7 +325,7 @@ Apple Developer account.
 You must then calculate the hashes for each file and create the `manifest.json` file. It will look something like this when you’re
 done:
 
-```csharp
+```json
 {
   "icon@2x.png" : "30806547dcc6ee084a90210e2dc042d5d7d92a41",
   "icon.png" : "87e9ffb203beb2cce5de76113f8e9503aeab6ecc",
@@ -482,7 +482,7 @@ options.
 
 If you experience this error when deploying:
 
-```csharp
+```
 Installation failed: Your code signing/provisioning profiles are not correctly configured (error: 0xe8008016)
 ```
 


### PR DESCRIPTION
It's a shame that JSON can't include comments, because the big code block on the top is quite hard to read without syntax highlighting.