### PR TITLE
blog.xamarin.com -> devblogs.microsoft.com

### DIFF
--- a/docs/xamarin-forms/user-interface/layouts/tablet.md
+++ b/docs/xamarin-forms/user-interface/layouts/tablet.md
@@ -110,11 +110,11 @@ is ideal for larger screens, especially on the iPad
 where it uses the [`UISplitViewController`](xref:UIKit.UISplitViewController)
 to provide a native iOS experience.
 
-Review [this Xamarin blog post](https://blog.xamarin.com/bringing-xamarin-forms-apps-to-tablets/)
+Review [this Xamarin blog post](https://devblogs.microsoft.com/xamarin/bringing-xamarin-forms-apps-to-tablets/)
 to see how you can adapt your user interface so that phones use one
 layout and larger screens can use another (with the `MasterDetailPage`).
 
 ## Related Links
 
-- [Xamarin Blog](https://blog.xamarin.com/bringing-xamarin-forms-apps-to-tablets/)
+- [Xamarin Blog](https://devblogs.microsoft.com/xamarin/bringing-xamarin-forms-apps-to-tablets/)
 - [MyShoppe sample](https://github.com/jamesmontemagno/myshoppe)


### PR DESCRIPTION
Replaced the old Xamarin Blog links with correct ones on devblogs.microsoft.com because they were redirecting to the main page of the blog.