### PR TITLE
fix: MD037/no-space-in-emphasis

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -26,7 +26,6 @@
   },
   "MD034": false,
   "MD036": false,
-  "MD037": false,
   "MD040": false,
   "MD041": false,
   "MD045": false,

--- a/docs/graphics-games/monogame/3d/part3.md
+++ b/docs/graphics-games/monogame/3d/part3.md
@@ -346,7 +346,7 @@ The final line of code combines the two matrices into one:
 Matrix combined = translationMatrix * rotationMatrix;
 ```
 
-This is referred to as matrix multiplication, which works slightly different than regular multiplication. The *commutative property of multiplication* states that the order of numbers in a multiplication operation does not change the result. That is, 3 * 4 is equivalent to 4 * 3. Matrix multiplication differs in that it is not commutative. That is, the above line can be read as "Apply the translationMatrix to move the model, then rotate everything by applying the rotationMatrix". We could visualize the way that the above line affects the position and rotation as follows:
+This is referred to as matrix multiplication, which works slightly different than regular multiplication. The *commutative property of multiplication* states that the order of numbers in a multiplication operation does not change the result. That is, 3 \* 4 is equivalent to 4 \* 3. Matrix multiplication differs in that it is not commutative. That is, the above line can be read as "Apply the translationMatrix to move the model, then rotate everything by applying the rotationMatrix". We could visualize the way that the above line affects the position and rotation as follows:
 
 ![](part3-images/image8.png "A visualization pf the way that the above line affects the position and rotation")
 

--- a/docs/ios/troubleshooting/mtouch-errors.md
+++ b/docs/ios/troubleshooting/mtouch-errors.md
@@ -99,7 +99,7 @@ An error occurred while parsing the command line arguments. Please verify that t
 
 <a name="MT0011" />
 
-### MT0011: * was built against a more recent runtime (*) than MonoTouch supports.
+### MT0011: \* was built against a more recent runtime (\*) than MonoTouch supports.
 
 This warning is typically reported because the project has a reference to a class library that was not built using the Xamarin.iOS BCL.
 
@@ -121,7 +121,7 @@ SGen (--sgen) must be enabled if profiling (--profiling) is enabled.
 
 <a name="MT0014" />
 
-### MT0014: The iOS * SDK does not support building applications targeting *.
+### MT0014: The iOS \* SDK does not support building applications targeting \*.
 
 This can happen in the following circumstances:
 
@@ -199,7 +199,7 @@ The executable assembly's name and the application's name can't match the name o
 
 <a name="MT0026" />
 
-### MT0026: Could not parse the command line argument '*': *
+### MT0026: Could not parse the command line argument '\*': \*
 
 <a name="MT0027" />
 
@@ -243,7 +243,7 @@ To fix this either change 'Application Name' in the project's Build/iOS Applicat
 
 <a name="MT0036" />
 
-### MT0036: Cannot launch a * simulator for a * app. Please enable the correct architecture(s) in your project's iOS Build options (Advanced page).
+### MT0036: Cannot launch a \* simulator for a \* app. Please enable the correct architecture(s) in your project's iOS Build options (Advanced page).
 
 <a name="MT0037" />
 
@@ -295,7 +295,7 @@ Install a newer Xcode version.
 
 <a name="MT0049" />
 
-### MT0049: *.framework is supported only if deployment target is 8.0 or later. * features might not work correctly.
+### MT0049: \*.framework is supported only if deployment target is 8.0 or later. \* features might not work correctly.
 
 The specified framework is not supported in the iOS version the deployment target refers to. Either update the deployment target to a newer iOS version, or remove usage of the specified framework from the app.
 
@@ -303,7 +303,7 @@ The specified framework is not supported in the iOS version the deployment targe
 
 <a name="MT0051" />
 
-### MT0051: Xamarin.iOS * requires Xcode 5.0 or later. The current Xcode version (found in *) is *.
+### MT0051: Xamarin.iOS \* requires Xcode 5.0 or later. The current Xcode version (found in \*) is \*.
 
 Install a newer Xcode.
 
@@ -317,7 +317,7 @@ No action was specified for mtouch.
 
 <a name="MT0054" />
 
-### MT0054: Unable to canonicalize the path '*': *
+### MT0054: Unable to canonicalize the path '\*': \*
 
 This is an internal error. If you see this error, please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new).
 
@@ -379,7 +379,7 @@ Xamarin.iOS only supports embedded frameworks when using the Unified API; please
 
 <a name="MT0065" />
 
-### MT0065: Xamarin.iOS only supports embedded frameworks when deployment target is at least 8.0 (current deployment target: * embedded frameworks: *)
+### MT0065: Xamarin.iOS only supports embedded frameworks when deployment target is at least 8.0 (current deployment target: \* embedded frameworks: \*)
 
 Xamarin.iOS only supports embedded frameworks when the deployment target is at least 8.0 (because earlier versions of iOS does not support embedded frameworks).
 
@@ -427,7 +427,7 @@ This usually indicates a bug in Xamarin.iOS; please file a new issue on [github]
 
 <a name="MT0073" />
 
-### MT0073: Xamarin.iOS * does not support a deployment target of * (the minimum is *). Please select a newer deployment target in your project's Info.plist.
+### MT0073: Xamarin.iOS \* does not support a deployment target of \* (the minimum is \*). Please select a newer deployment target in your project's Info.plist.
 
 The minimum deployment target is the one specified in the error message; please select a newer deployment target in the project's Info.plist.
 
@@ -435,7 +435,7 @@ If updating the deployment target is not possible, then please use an older vers
 
 <a name="MT0074" />
 
-### MT0074: Xamarin.iOS * does not support a minimum deployment target of * (the maximum is *). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of Xamarin.iOS.
+### MT0074: Xamarin.iOS \* does not support a minimum deployment target of \* (the maximum is \*). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of Xamarin.iOS.
 
 Xamarin.iOS does not support setting the minimum deployment target to a higher version than the version this particular version of Xamarin.iOS was built for.
 
@@ -443,7 +443,7 @@ Please select an older minimum deployment target in the project's Info.plist, or
 
 <a name="MT0075" />
 
-### MT0075: Invalid architecture '*' for * projects. Valid architectures are: *
+### MT0075: Invalid architecture '\*' for \* projects. Valid architectures are: \*
 
 An invalid architecture was specified. Please verify that architecture is valid.
 
@@ -469,7 +469,7 @@ Incremental builds are only supported when the deployment target is at least 8.0
 
 <a name="MT0079" />
 
-### MT0079: The recommended Xcode version for Xamarin.iOS * is Xcode * or later. The current Xcode version (found in *) is *.
+### MT0079: The recommended Xcode version for Xamarin.iOS \* is Xcode \* or later. The current Xcode version (found in \*) is \*.
 
 This is a warning informing that the current version of Xcode is not the recommended version of Xcode for this version of Xamarin.iOS.
 
@@ -523,7 +523,7 @@ This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https:/
 
 <a name="MT0091" />
 
-### MT0091: This version of Xamarin.iOS requires the * SDK (shipped with Xcode *). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).
+### MT0091: This version of Xamarin.iOS requires the \* SDK (shipped with Xcode \*). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only (to try to avoid the new APIs).
 
 Xamarin.iOS requires the header files, from the SDK version specified in the error message, to build your application. The recommended way to fix this error is to upgrade Xcode to get the required SDK, this will include all the required header files. If you have multiple versions of Xcode installed, or want to use an Xcode in a non-default location, make sure to set the correct Xcode location in your IDE's preferences.
 
@@ -791,7 +791,7 @@ earlier iOS version.
 
 <a name="MT0123" />
 
-### MT0123: The executable assembly * does not reference *.
+### MT0123: The executable assembly \* does not reference \*.
 
 No reference could be found to the platform assembly (Xamarin.iOS.dll / Xamarin.TVOS.dll / Xamarin.WatchOS.dll) in the executable assembly.
 
@@ -848,7 +848,7 @@ For further information see bug #[52727](https://bugzilla.xamarin.com/show_bug.c
 
 <a name="MT0128" />
 
-### MT0128: Could not touch the file '*': *
+### MT0128: Could not touch the file '\*': \*
 
 A failure occurred when touching a file (which is done to ensure partial builds are done correctly).
 
@@ -938,7 +938,7 @@ with your full version information and build log output.
 
 <a name="MT1010" />
 
-### MT1010: Could not load the assembly '*': *
+### MT1010: Could not load the assembly '\*': \*
 
 <a name="MT1011" />
 
@@ -946,7 +946,7 @@ with your full version information and build log output.
 
 <a name="MT1012" />
 
-### MT1012: Failed to list the apps on the device '*': *
+### MT1012: Failed to list the apps on the device '\*': \*
 
 <a name="MT1013" />
 
@@ -960,11 +960,11 @@ This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https:/
 
 <a name="MT1015" />
 
-### MT1015: Failed to create the executable '*': *
+### MT1015: Failed to create the executable '\*': \*
 
 <a name="MT1015" />
 
-### MT1015: Failed to create the executable '*': *
+### MT1015: Failed to create the executable '\*': \*
 
 <a name="MT1016" />
 
@@ -1015,7 +1015,7 @@ A directory could not be copied. The error message from the copy operation has m
 
 <a name="MT1023" />
 
-### MT1023: Could not communicate with the device to find the application '*' : *
+### MT1023: Could not communicate with the device to find the application '\*' : \*
 
 An error occurred when trying to lookup an application on device.
 
@@ -1050,7 +1050,7 @@ Things to try to solve this:
 
 <a name="MT1026" />
 
-### MT1026: Could not download the crash report * from the device *.
+### MT1026: Could not download the crash report \* from the device \*.
 
 An error occurred when trying to download the crash reports from the device.
 
@@ -1239,7 +1239,7 @@ If you're deploying an enterprise app or using a free provisioning profile, you 
 
 <a name="MT1212" />
 
-### MT1212: Failed to create a simulator version where type = * and runtime = *.
+### MT1212: Failed to create a simulator version where type = \* and runtime = \*.
 
 <a name="MT1213" />
 
@@ -1313,7 +1313,7 @@ Please review the bulid log for more information about this failure from the nat
 
 <a name="MT1304" />
 
-### MT1304: The embedded framework '*' in * is invalid: it does not contain an Info.plist.
+### MT1304: The embedded framework '\*' in \* is invalid: it does not contain an Info.plist.
 
 The specified embedded framework does not contain an Info.plist, and is therefore not a valid framework.
 
@@ -1363,7 +1363,7 @@ Things to try to solve this:
 
 <a name="MT1402" />
 
-### MT1402: Could not read file info for *: AFCFileInfoOpen returned *
+### MT1402: Could not read file info for \*: AFCFileInfoOpen returned \*
 
 An error occurred when trying to access crash reports from the device.
 
@@ -1377,7 +1377,7 @@ Things to try to solve this:
 
 <a name="MT1403" />
 
-### MT1403: Could not read crash report: AFCDirectoryOpen (*) returned: *
+### MT1403: Could not read crash report: AFCDirectoryOpen (\*) returned: \*
 
 An error occurred when trying to access crash reports from the device.
 
@@ -1391,7 +1391,7 @@ Things to try to solve this:
 
 <a name="MT1404" />
 
-### MT1404: Could not read crash report: AFCFileRefOpen (*) returned: *
+### MT1404: Could not read crash report: AFCFileRefOpen (\*) returned: \*
 
 An error occurred when trying to access crash reports from the device.
 
@@ -1405,7 +1405,7 @@ Things to try to solve this:
 
 <a name="MT1405" />
 
-### MT1405: Could not read crash report: AFCFileRefRead (*) returned: *
+### MT1405: Could not read crash report: AFCFileRefRead (\*) returned: \*
 
 An error occurred when trying to access crash reports from the device.
 
@@ -1419,7 +1419,7 @@ Things to try to solve this:
 
 <a name="MT1406" />
 
-### MT1406: Could not list crash reports: AFCDirectoryOpen (*) returned: *
+### MT1406: Could not list crash reports: AFCDirectoryOpen (\*) returned: \*
 
 An error occurred when trying to access crash reports from the device.
 
@@ -1483,7 +1483,7 @@ file -arch all -l /path/to/library.dylib
 
 <a name="MT1603" />
 
-### MT1603: Unknown format for fat entry at position * in *.
+### MT1603: Unknown format for fat entry at position \* in \*.
 
 An error occurred while processing the fat archive in question.
 
@@ -1497,7 +1497,7 @@ file -arch all -l /path/to/file
 
 <a name="MT1604" />
 
-### MT1604: File of type * is not a MachO file (*).
+### MT1604: File of type \* is not a MachO file (\*).
 
 An error occurred while processing the MachO file in question.
 
@@ -1885,11 +1885,11 @@ This is always a bug in Xamarin.iOS; please file a new issue on [github](https:/
 
 <a name="MT4116" />
 
-### MT4116: Could not register the assembly '*': *
+### MT4116: Could not register the assembly '\*': \*
 
 <a name="MT4117" />
 
-### MT4117: The registrar found a signature mismatch in the method '*.*' - the selector indicates the method takes * parameters, while the managed method has * parameters.
+### MT4117: The registrar found a signature mismatch in the method '\*.\*' - the selector indicates the method takes \* parameters, while the managed method has \* parameters.
 
 <a name="MT4118" />
 
@@ -1919,7 +1919,7 @@ This error indicates a bug in Xamarin.iOS. Please file a new issue on [github](h
 
 <a name="MT4124" />
 
-### MT4124: Invalid * found on '*'. Please file a bug report at http://bugzilla.xamarin.com
+### MT4124: Invalid \* found on '\*'. Please file a bug report at http://bugzilla.xamarin.com
 
 This error indicates a bug in Xamarin.iOS. Please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new).
 
@@ -1961,7 +1961,7 @@ This error indicates a bug in Xamarin.iOS. Please file a new issue on [github](h
 
 <a name="MT4134" />
 
-### MT4134: Your application is using the '*' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS *, while you're building with the iOS * SDK.) Please select a newer SDK in your app's iOS Build options.
+### MT4134: Your application is using the '\*' framework, which isn't included in the iOS SDK you're using to build your app (this framework was introduced in iOS \*, while you're building with the iOS \* SDK.) Please select a newer SDK in your app's iOS Build options.
 
 <a name="MT4135" />
 
@@ -1983,7 +1983,7 @@ This error indicates a bug in Xamarin.iOS. Please file a new issue on [github](h
 
 <a name="MT4140" />
 
-### MT4140: The registrar found a signature mismatch in the method '*.*' - the selector indicates the variadic method takes * parameters, while the managed method has * parameters.
+### MT4140: The registrar found a signature mismatch in the method '\*.\*' - the selector indicates the variadic method takes \* parameters, while the managed method has \* parameters.
 
 <a name="MT4141" />
 
@@ -2099,7 +2099,7 @@ Please verify that the `Register` attribute on the managed class mentioned in th
 
 <a name="MT4158" />
 
-### MT4158: Cannot register the constructor * in the category * because constructors in categories are not supported.
+### MT4158: Cannot register the constructor \* in the category \* because constructors in categories are not supported.
 
 <a name="MT4159" />
 
@@ -2995,7 +2995,7 @@ Where * can be:
 
 <a name="MT8004" />
 
-### MT8004: Cannot create an instance of * for the native object 0x* (of type '*'), because another instance already exists for this native object (of type *).
+### MT8004: Cannot create an instance of \* for the native object 0x* (of type '\*'), because another instance already exists for this native object (of type \*).
 
 <a name="MT8005" />
 
@@ -3011,7 +3011,7 @@ Where * can be:
 
 <a name="MT8008" />
 
-### MT8008: The loaded version of Xamarin.iOS.dll was compiled for * bits, while the process is * bits. Please file a bug at http://bugzilla.xamarin.com.
+### MT8008: The loaded version of Xamarin.iOS.dll was compiled for \* bits, while the process is \* bits. Please file a bug at http://bugzilla.xamarin.com.
 
 This indicates something is wrong in the build process. Please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new).
 
@@ -3091,7 +3091,7 @@ This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https:/
 
 <a name="MT8020" />
 
-### MT8020: Could not find the module with MetadataToken * in the assembly *.
+### MT8020: Could not find the module with MetadataToken \* in the assembly \*.
 
 This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new).
 
@@ -3103,13 +3103,13 @@ This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https:/
 
 <a name="MT8022" />
 
-### MT8022: Expected the token reference * to be a *, but it's a *. Please file a bug report at http://bugzilla.xamarin.com.
+### MT8022: Expected the token reference \* to be a \*, but it's a \*. Please file a bug report at http://bugzilla.xamarin.com.
 
 This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new).
 
 <a name="MT8023" />
 
-### MT8023: An instance object is required to construct a closed generic method for the open generic method: * (token reference: *). Please file a bug report at http://bugzilla.xamarin.com.
+### MT8023: An instance object is required to construct a closed generic method for the open generic method: \* (token reference: \*). Please file a bug report at http://bugzilla.xamarin.com.
 
 This indicates a bug in Xamarin.iOS. Please file a new issue on [github](https://github.com/xamarin/xamarin-macios/issues/new).
 

--- a/docs/mac/troubleshooting/mmp-errors.md
+++ b/docs/mac/troubleshooting/mmp-errors.md
@@ -120,7 +120,7 @@ This usually indicates a bug in Xamarin.Mac; please file a bug report at [https:
 
 <a name="MM0073" />
 
-#### MM0073: Xamarin.Mac * does not support a deployment target of * (the minimum is *). Please select a newer deployment target in your project's Info.plist.
+#### MM0073: Xamarin.Mac \* does not support a deployment target of \* (the minimum is \*). Please select a newer deployment target in your project's Info.plist.
 
 The minimum deployment target is the one specified in the error message; please select a newer deployment target in the project's Info.plist.
 
@@ -128,7 +128,7 @@ If updating the deployment target is not possible, then please use an older vers
 
 <a name="MM0074" />
 
-#### MM0074: Xamarin.Mac * does not support a deployment target of * (the maximum is *). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of Xamarin.Mac.
+#### MM0074: Xamarin.Mac \* does not support a deployment target of \* (the maximum is \*). Please select an older deployment target in your project's Info.plist or upgrade to a newer version of Xamarin.Mac.
 
 Xamarin.Mac does not support setting the minimum deployment target to a higher version than the version this particular version of Xamarin.Mac was built for.
 
@@ -147,7 +147,7 @@ Please select an older minimum deployment target in the project's Info.plist, or
 
 <a name="MM0091" />
 
-#### MM0091: This version of Xamarin.Mac requires the * SDK (shipped with Xcode *). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only (to try to avoid the new APIs).
+#### MM0091: This version of Xamarin.Mac requires the \* SDK (shipped with Xcode \*). Either upgrade Xcode to get the required header files or use the dynamic registrar or set the managed linker behaviour to Link Platform or Link Framework SDKs Only (to try to avoid the new APIs).
 
 Xamarin.Mac requires the header files, from the SDK version specified in the error message, to build your application with the static registrar. The recommended way to fix this error is to upgrade Xcode to get the required SDK, this will include all the required header files. If you have multiple versions of Xcode installed, or want to use an Xcode in a non-default location, make sure to set the correct Xcode location in your IDE's preferences.
 
@@ -199,7 +199,7 @@ When running `--runregistrar`, the assembly list should include the product asse
 
 <a name="MM0132" />
 
-#### MM0132: Unknown optimization: *. Valid values are: *
+#### MM0132: Unknown optimization: \*. Valid values are: \*
 
 The specified optimization was not recognized.
 
@@ -333,7 +333,7 @@ As a last-straw solution, use an older version of Xamarin.Mac that does not requ
 
 <a name="MM2009" />
 
-#### MM2009: Referenced by {0}.{1}     ** This message is related to MM2006 **
+#### MM2009: Referenced by {0}.{1}     \*\* This message is related to MM2006 \*\*
 
 <a name="MM2010" />
 
@@ -345,7 +345,7 @@ As a last-straw solution, use an older version of Xamarin.Mac that does not requ
 
 <a name="MM2012" />
 
-#### MM2012: Only first {0} of {1} "Referenced by" warnings shown. ** This message related to 2009 **
+#### MM2012: Only first {0} of {1} "Referenced by" warnings shown. \*\* This message related to 2009 \*\*
 
 <a name="MM2013" />
 
@@ -353,7 +353,7 @@ As a last-straw solution, use an older version of Xamarin.Mac that does not requ
 
 <a name="MM2014" />
 
-#### MM2014: Xamarin.Mac Extensions do not support linking. Request for linking will be ignored. ** This message is obsolete in XM 3.6+ **
+#### MM2014: Xamarin.Mac Extensions do not support linking. Request for linking will be ignored. \*\* This message is obsolete in XM 3.6+ \*\*
 
 <!-- 2015 used by mtouch -->
 
@@ -391,7 +391,7 @@ See https://docs.microsoft.com/cpp/dotnet/mixed-native-and-managed-assemblies fo
 
 <a name="MM2106" />
 
-#### MM2106: Could not optimize the call to BlockLiteral.SetupBlock[Unsafe] in * at offset * because *.
+#### MM2106: Could not optimize the call to BlockLiteral.SetupBlock[Unsafe] in \* at offset \* because \*.
 
 The linker reports this warning when it can't optimize a call to `BlockLiteral.SetupBlock` or `Block.SetupBlockUnsafe`.
 

--- a/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/summaries/chapter03.md
+++ b/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/summaries/chapter03.md
@@ -58,7 +58,7 @@ You can also use several static methods to create `Color` values:
 - [`Color.FromRgba`](xref:Xamarin.Forms.Color.FromRgba(System.Double,System.Double,System.Double,System.Double)) for `double` RGB values with transparency
 - [`Color.FromRgba`](xref:Xamarin.Forms.Color.FromRgba(System.Int32,System.Int32,System.Int32,System.Int32)) for integer RGB values with transparency
 - [`Color.FromHsla`](xref:Xamarin.Forms.Color.FromHsla(System.Double,System.Double,System.Double,System.Double)) for `double` HSL values with transparency
-- [`Color.FromUint`](xref:Xamarin.Forms.Color.FromUint(System.UInt32)) for a `uint` value calculated as (B + 256 * (G + 256 * (R + 256 * A)))
+- [`Color.FromUint`](xref:Xamarin.Forms.Color.FromUint(System.UInt32)) for a `uint` value calculated as (B + 256 \* (G + 256 \* (R + 256 \* A)))
 - [`Color.FromHex`](xref:Xamarin.Forms.Color.FromHex(System.String)) for a `string` format of hexadecimal digits in the form "#AARRGGBB" or "#RRGGBB" or "#ARGB" or "#RGB", where each letter corresponds to a hexadecimal digit for the alpha, red, green, and blue channels. This method is primary used for XAML color conversions as discussed in [Chapter 7, XAML vs. code](~/xamarin-forms/creating-mobile-apps-xamarin-forms/summaries/chapter07.md).
 
 Once created, a `Color` value is immutable. The characteristics of the color can be obtained from the following properties:

--- a/docs/xamarin-forms/user-interface/text/label.md
+++ b/docs/xamarin-forms/user-interface/text/label.md
@@ -180,7 +180,6 @@ The following screenshots show the result of setting the `MaxLines` property to 
 
 ![Label MaxLines Example](label-images/label-maxlines.png)
 
-
 ## Display HTML
 
 The [`Label`](xref:Xamarin.Forms.Label) class has a `TextType` property, which determines whether the `Label` instance should display plain text, or HTML text. This property should be set to one of the members of the `TextType` enumeration:


### PR DESCRIPTION
Was mostly just escaping some asterisks that Markdownlint flagged as ambiguous