### PR TITLE
fix: MD022/blanks-around-heading

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,7 +4,6 @@
   "MD009": false,
   "MD013": false,
   "MD014": false,
-  "MD022": false,
   "MD024": false,
   "MD025": false,
   "MD026": false,

--- a/contributing-guidelines/template.md
+++ b/contributing-guidelines/template.md
@@ -84,8 +84,11 @@ If your heading finishes with a `#` character, you need to add an extra `#` char
 Second-level headings will generate the on-page TOC that appears in the "In this article" section underneath the on-page title.
 
 ### Third-level heading
+
 #### Fourth-level heading
+
 ##### Fifth level heading
+
 ###### Sixth-level heading
 
 ## Text styling

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -1,7 +1,13 @@
 # [Xamarin Documentation](index.yml)
+
 ## [Android](android/index.yml)
+
 ## [iOS](ios/index.yml)
+
 ## [Mac](mac/index.yml)
+
 ## [Xamarin.Forms](xamarin-forms/index.yml)
+
 ## [Cross-Platform](cross-platform/index.yml)
+
 ## [Tools](tools/index.yml)

--- a/docs/android/app-fundamentals/notifications/local-notifications.md
+++ b/docs/android/app-fundamentals/notifications/local-notifications.md
@@ -152,6 +152,7 @@ notifications.
 
 <a name="notif-chan"></a>
 <a name="notification-channels"></a>
+
 ## Notification channels
 
 Beginning with Android 8.0 (Oreo), you can use the *notification

--- a/docs/android/platform/fragments/implementing-with-fragments/walkthrough.md
+++ b/docs/android/platform/fragments/implementing-with-fragments/walkthrough.md
@@ -24,6 +24,7 @@ The following classes will be created for this app:
 ## 1. Create the Android project
 
 Create a new Xamarin.Android project called **FragmentSample**.
+
 # [Visual Studio](#tab/windows)
 
 [![Create a new Xamarin.Android project](./walkthrough-images/01-newproject.w157-sml.png)](./walkthrough-images/01-newproject.w157.png#lightbox)

--- a/docs/android/troubleshooting/questions/install-android-sdk-packages.md
+++ b/docs/android/troubleshooting/questions/install-android-sdk-packages.md
@@ -46,8 +46,10 @@ emulators from Google. For more information, see
 [Android Emulator Setup](~/android/get-started/installation/android-emulator/index.md)
 
 ## Extras
+
 The Android SDK Extras are usually not required; but it is useful to be aware of them since they may be required depending on your use case.
 
 ## Further Reading
+
 The following guide covers these options and goes into more detail about the different packages the SDK manager has avaliable:
 [Android SDK Manager Setup Guide](http://www.themethodology.net/2015/02/android-sdk-manager-setup-for.html?m=1)

--- a/docs/android/troubleshooting/troubleshooting.md
+++ b/docs/android/troubleshooting/troubleshooting.md
@@ -270,6 +270,7 @@ I/monodroid-gref(27679): -g- grefc 1952 gwrefc 259 handle 0x4066df10/G from take
 ```
 
 ## Object is still alive, as handle != null
+
 ## wref turned back into a gref
 
 ```shell
@@ -279,6 +280,7 @@ I/monodroid-gref(27679): -w- grefc 1930 gwrefc 38 handle 0xde68f95f/W from take_
 ```
 
 ## Object is dead, as handle == null
+
 ## wref is freed, no new gref created
 
 ```shell

--- a/docs/cross-platform/app-fundamentals/building-cross-platform-applications/case-study-tasky.md
+++ b/docs/cross-platform/app-fundamentals/building-cross-platform-applications/case-study-tasky.md
@@ -504,6 +504,7 @@ All references to the PCL library are through the `TaskItemManager` class.
  <a name="Windows_Phone_App" />
 
 ## Windows Phone App
+
 The complete Windows Phone project:
 
  ![](case-study-tasky-images/taskywp7-solution.png "Windows Phone App The complete Windows Phone project")

--- a/docs/cross-platform/macios/apple-account-management.md
+++ b/docs/cross-platform/macios/apple-account-management.md
@@ -149,6 +149,7 @@ This is currently a known issue, relating to bug [#53906](https://bugzilla.xamar
 This is because 2 factor authentication is enabled on your account. Make sure that you are using the latest stable version of Visual Studio for Mac
 
 ### Failed to create new certificate
+
 "You have reached the limit for certificates of this type"
 
 ![certificate limit dialog](apple-account-management-images/image10.png)

--- a/docs/cross-platform/platform/csharp-six.md
+++ b/docs/cross-platform/platform/csharp-six.md
@@ -32,7 +32,9 @@ Visual Studio for Mac users can check if they have Mono 4 (or newer) installed b
 **About Visual Studio for Mac > Visual Studio for Mac > Show Details**.
 
 ## Less Boilerplate
+
 ### using static
+
 Enumerations, and certain classes such as `System.Math`, are primarily holders of static values and functions. In C# 6, you can import all static members of a type with a single `using static` statement. Compare a typical trigonometric function in C# 5 and C# 6:
 
 ```csharp
@@ -88,6 +90,7 @@ class Program
 The previous example demonstrates the difference in behavior: the extension method `Enumerable.Where` is associated with the array, while the static method `String.Join` can be called without reference to the `String` type.
 
 ### nameof Expressions
+
 Sometimes, you want to refer to the name you’ve given a variable or field. In C# 6, `nameof(someVariableOrFieldOrType)` will return the string `"someVariableOrFieldOrType"`. For instance, when throwing an `ArgumentException` you’re very likely to want to name which argument is invalid:
 
 ```csharp
@@ -118,6 +121,7 @@ var myLabelNew.SetBinding (Label.TextProperty, nameof(ReactiveType.StringField))
 The two calls to `SetBinding` are passing identical values: `nameof(ReactiveType.StringField)` is `"StringField"`, not `"ReactiveType.StringField"` as you might initially expect.
 
 ## Null-conditional Operator
+
 Earlier updates to C# introduced the concepts of nullable types and the null-coalescing operator `??` to reduce the amount of boilerplate code when handling nullable values. C# 6 continues this theme with the "null-conditional operator" `?.`. When used on an object on the right-hand side of an expression, the null-conditional operator returns the member value if the object is not `null` and `null` otherwise:
 
 ```csharp
@@ -151,6 +155,7 @@ public override bool ContinueUserActivity (UIApplication application, NSUserActi
 ```
 
 ## String Interpolation
+
 The `String.Format` function has traditionally used indices as placeholders in the format string, e.g., `String.Format("Expected: {0} Received: {1}.", expected, received`). Of course, adding a new value has always involved an annoying little task of counting up arguments, renumbering placeholders, and inserting the new argument in the right sequence in the argument list.
 
 C# 6's new string interpolation feature greatly improves upon `String.Format`. Now, you can directly name variables in a string prefixed with a `$`. For instance:

--- a/docs/cross-platform/troubleshooting/questions/index.md
+++ b/docs/cross-platform/troubleshooting/questions/index.md
@@ -13,39 +13,53 @@ ms.date: 05/08/2018
 ## Portable Class Libraries
 
 ### [How can I view what libraries are supported in a PCL?](pcl-support-libraries.md)
+
 This guide lists resources and methods for determining if your existing library is supported by the various PCL target platforms, or can be converted to a PCL profile.
 
 ### [PCL Reflection API](pcl-reflection.md)
+
 Microsoft developed a new Reflection API for use in Portable Class Libraries. If you have some existing Reflection code that you want to move to a PCL, it might not work.
 
 ### [PCL case study: How can I resolve problems related to System.Diagnostics.Tracing for the Microsoft TPL Dataflow NuGet package?](pcl-case-study.md)
+
 Xamarin.iOS and Xamarin.Android do not implement 100% of every PCL profile that they allow as references. For practical convenience in Visual Studio for Mac, Visual Studio, and the NuGet package manager, Xamarin projects allow the use of several profiles that only have incomplete implementations. For example, neither Xamarin.iOS nor Xamarin.Android currently includes a complete implementation of the types in the `System.Diagnostics.Tracing` PCL namespace. You can work around this by switching the app project to reference the portable-net45+win8+wp8+wpa81 version of the TPL Dataflow library.
 
 ## NuGet packages & Xamarin Components
+
 ### [How can I update NuGet?](nuget-update.md)
+
 NuGet updates, extensions, and add-ins can be found under the **Updates** tab in the **NuGet Package Manager**. Detailed navigation to find the updates in Visual Studio for Mac & Visual Studio is in this guide.
 
 ### [How do I downgrade a NuGet package?](nuget-package-downgrade.md)
+
 Visual Studio for Mac & Visual Studio both have features for selecting older versions of packages and installing them automatically; similar to how updating packages works.
 
 ### [Missing packages error after updating Nuget packages](nuget-packages-missing.md)
+
 This issue has mainly been reported on Xamarin.Forms sample app solutions, but the potential for this issue can happen on any project that uses NuGet packages.
 
 ### [Unifying Google Play Services Components and NuGet](gps-components-nuget.md)
+
 There used to be several Google Play Services Components and NuGet packages, but To make things easier for developers, we've now unified our Components and NuGet packages into two. In almost every case, Google Play Services should be used. The only reason to use the (Froyo) package is if you are actively targeting Froyo.
 
 ### [Where are the components stored on my machine?](component-storage.md)
+
 Whenever you install a Xamarin component into an App project, it gets placed in the two locations listed in this guide.
 
 ## Troubleshooting
+
 ### [Where can I find my version information and logs?](version-logs.md)
+
 This guide details where to find most diagnostic information that can be used to troubleshoot Xamarin issues.
 
 ### [When and how should I file a bug report?](howto-file-bug.md)
+
 This guide provides tips for filing high-quality bug reports, so that our engineers are able to determine the cause (and any potential fixes) for an issue more efficiently.
 
 ### [Why isn't Jenkins supported by Xamarin?](xamarin-jenkins.md)
+
 Jenkins is an open-source CI suite; because of this many issues that are directly caused by the Jenkins *itself* will need to be filed as issues against where you got the code; such as the [main Jenkins repo](https://github.com/jenkinsci/jenkins), or the repo for [Jenkins.app](https://github.com/stisti/jenkins-app).
 
 ### [What project settings are required for the debugger?](debugger-settings.md)
+
 In order for the debugger to work as expected (hit breakpoints, display debug logs, etc.), developer instrumentation and debug information display must both be enabled. This guide details how to find and activate these settings.

--- a/docs/cross-platform/troubleshooting/questions/xamarin-jenkins.md
+++ b/docs/cross-platform/troubleshooting/questions/xamarin-jenkins.md
@@ -37,6 +37,7 @@ Your options for setting the SDK location may vary depending on the exact Jenkin
 > This issue has been resolved in recent versions of Xamarin. However, if the issue occurs on the latest version of the software, please file a [new bug](~/cross-platform/troubleshooting/questions/howto-file-bug.md) with your full versioning information and full build log output.
 
 ### Jenkins reports an invalid Xamarin license
+
 The error messages for this issue are typically something like
 
 > XA9008 error: Building from command line requires a business license

--- a/docs/essentials/geolocation.md
+++ b/docs/essentials/geolocation.md
@@ -184,6 +184,7 @@ The following table outlines accuracy per platform:
 <a name="calculate-distance" />
 
 ## Detecting Mock Locations
+
 Some devices may return a mock location from the provider or by an application that provides mock locations. You can detect this by using the `IsFromMockProvider` on any [`Location`](xref:Xamarin.Essentials.Location).
 
 ```csharp

--- a/docs/essentials/secure-storage.md
+++ b/docs/essentials/secure-storage.md
@@ -24,6 +24,7 @@ To access the **SecureStorage** functionality, the following platform-specific s
 > [Auto Backup for Apps](https://developer.android.com/guide/topics/data/autobackup) is a feature of Android 6.0 (API level 23) and later that backs up user's app data (shared preferences, files in the app's internal storage, and other specific files). Data is restored when an app is re-installed or installed on a new device. This can impact `SecureStorage` which utilizes share preferences that are backed up and can not be decrypted when the restore occurs. Xamarin.Essentials automatically handles this case by removing the key so it can be reset, but you can take an additional step by disabling Auto Backup.
 
 ### Enable or disable backup
+
 You can choose to disable Auto Backup for your entire application by setting the `android:allowBackup` setting to false in the `AndroidManifest.xml` file. This approach is only recommended if you plan on restoring data in another way.
 
 ```xml
@@ -36,6 +37,7 @@ You can choose to disable Auto Backup for your entire application by setting the
 ```
 
 ### Selective Backup
+
 Auto Backup can be configured to disable specific content from backing up. You can create a custom rule set to exclude `SecureStore` items from being backed up.
 
 1. Set the `android:fullBackupContent` attribute in your **AndroidManifest.xml**:

--- a/docs/graphics-games/TOC.md
+++ b/docs/graphics-games/TOC.md
@@ -1,26 +1,47 @@
 # [Graphics & Games](index.yml)
+
 ## [Game Development](game-development/index.md)
 
 ## [SkiaSharp](~/xamarin-forms/user-interface/graphics/skiasharp/index.md)
 
 ## [UrhoSharp](urhosharp/index.md)
+
 ### [Introduction](urhosharp/introduction.md)
+
 ### [Using UrhoSharp](urhosharp/using.md)
+
 ### [Platform Specific Notes](urhosharp/platform/index.md)
+
 #### [Android](urhosharp/platform/android.md)
+
 #### [iOS and tvOS](urhosharp/platform/ios.md)
+
 #### [macOS](urhosharp/platform/mac.md)
+
 #### [Windows](urhosharp/platform/windows.md)
+
 #### [Xamarin.Forms](urhosharp/platform/xamarin-forms.md)
+
 ### [Programming UrhoSharp with F#](urhosharp/fsharp.md)
+
 ## [MonoGame](monogame/index.md)
+
 ### [Introduction to MonoGame](monogame/introduction/index.md)
+
 #### [Part 1 - Creating a Cross Platform MonoGame Project](monogame/introduction/part1.md)
+
 #### [Part 2 - Implementing the WalkingGame](monogame/introduction/part2.md)
+
 ### [3D with MonoGame](monogame/3d/index.md)
+
 #### [Part 1 - Using the Model class](monogame/3d/part1.md)
+
 #### [Part 2 - Drawing 3D Graphics with Vertices](monogame/3d/part2.md)
+
 #### [Part 3 - 3D Coordinates](monogame/3d/part3.md)
+
 ### [GamePad Reference](monogame/input.md)
+
 ### [Platform Considerations](monogame/platforms/index.md)
+
 #### [Universal Windows Platform (UWP)](monogame/platforms/uwp.md)

--- a/docs/ios/deploy-test/app-distribution/ad-hoc-distribution.md
+++ b/docs/ios/deploy-test/app-distribution/ad-hoc-distribution.md
@@ -74,6 +74,7 @@ Alternatively, it is possible to request a Certificate via the Preferences dialo
 <a name="createappid" />
 
 ### Create an App ID
+
 As with any other Provisioning Profile you create, an App ID will be required to identify the App that will be distributed to the user's device. If you haven't already created this, follow the steps below to create one:
 
 1. In the [Apple Developer Center](https://developer.apple.com/account/overview.action) browse to the *Certificate, Identifiers and Profiles* section. Select **App IDs** under **Identifiers**.
@@ -140,6 +141,7 @@ When you are ready to do a final build of a Xamarin.iOS application, select the 
 5. Click the **OK** button to save the changes.
 
 # [Visual Studio](#tab/windows)
+
  In Visual Studio, do the following:
 
 1. Right-click the project name in the **Solution Explorer** and select **Properties** to open it for edit.

--- a/docs/ios/deploy-test/debugging-in-xamarin-ios.md
+++ b/docs/ios/deploy-test/debugging-in-xamarin-ios.md
@@ -75,6 +75,7 @@ Before you begin debugging any application, always ensure that the configuration
 -----
 
 ## Start Debugging
+
 To start debugging, select the target device or similar in your IDE:
 
 # [Visual Studio for Mac](#tab/macos)

--- a/docs/ios/deploy-test/testflight.md
+++ b/docs/ios/deploy-test/testflight.md
@@ -111,6 +111,7 @@ First, build your [final distributable](~/ios/deploy-test/app-distribution/app-s
  Refer to the [Submitting your App to Apple](~/ios/deploy-test/app-distribution/app-store-distribution/publishing-to-the-app-store.md) section for more information on these steps.
 
 ### Submitting your Build
+
  The publishing wizard will open the Application Loader program to all you to upload your build to iTunes Connect. Select the **Deliver Your App** option, and upload the `.ipa` file created above. The Application Loader will validate and upload your build to iTunes Connect.
 
  Refer to the [Submitting your App to Apple](~/ios/deploy-test/app-distribution/app-store-distribution/publishing-to-the-app-store.md) section for more information on these steps.
@@ -118,6 +119,7 @@ First, build your [final distributable](~/ios/deploy-test/app-distribution/app-s
 # [Visual Studio](#tab/windows)
 
 ### Building your final distributable
+
  As the Xamarin plugin for Visual Studio does not support archiving Xamarin.iOS apps for publishing to the App Store, there are two options for publishing an iOS application from Visual Studio. These are:
 
 1. Upload an IPA created via the Build Adhoc IPA command.
@@ -126,6 +128,7 @@ First, build your [final distributable](~/ios/deploy-test/app-distribution/app-s
  The [Building the Distributable](~/ios/deploy-test/app-distribution/app-store-distribution/publishing-to-the-app-store.md) guide has instructions for both of these options.
 
 ### Submitting your Build
+
  To submit your app to Apple, you will have to move to your Build Host and use the Application Loader program, which is installed as part of Xcode. For more information on accessing the Application Loader, see to Apple's [Access Application Loader](https://help.apple.com/itc/apploader/#/apdATD1E927-D1E1A1303-D1E927A1126) guide.
 
 Once opened, select the **Deliver Your App** option, and upload the zip or `.ipa` file created above. The Application Loader will validate and upload your build to iTunes Connect.

--- a/docs/ios/platform/gaming/spritekit.md
+++ b/docs/ios/platform/gaming/spritekit.md
@@ -18,6 +18,7 @@ SpriteKit, the 2D graphics framework from Apple, has some interesting new featur
 SpriteKit includes a 2D, rigid body physics API. Every sprite has an associated physics body (`SKPhysicsBody`) that defines the physics properties such as mass and friction, as well as the geometry of the body in the physics world.
 
 ## Creating a Physics Body from a Texture
+
 SpriteKit now supports deriving the physics body of a sprite from its texture. This makes it easy to implement collisions that look more natural.
 
 For example, notice in the following collision how the banana and monkey collide nearly at the surface of each image:

--- a/docs/ios/platform/healthkit.md
+++ b/docs/ios/platform/healthkit.md
@@ -39,6 +39,7 @@ The following are required to complete the steps presented in this article:
 > Health Kit was introduced in iOS 8. Currently, Health Kit is not available on the iOS simulator, and debugging requires connection to a physical iOS device.
 
 ## Creating and Provisioning A Health Kit App
+
 Before a Xamarin iOS 8 application can use the HealthKit API, it must be properly configured and provisioned. This section will cover the steps required to properly setup your Xamarin Application.
 
 Health Kit apps require:

--- a/docs/ios/platform/introduction-to-ios11/updating-your-app/visual-design.md
+++ b/docs/ios/platform/introduction-to-ios11/updating-your-app/visual-design.md
@@ -28,6 +28,7 @@ barItem.LargeContentSizeImage = UIImage.FromBundle("AccessibleImage");
 ```
 
 ### Navigation Bar
+
 iOS 11 introduced new functionality to make navigation bar titles easier to read. Apps can display this larger title by assigning the `PrefersLargeTitles` property to true:
 
 ```csharp

--- a/docs/ios/platform/introduction-to-ios8.md
+++ b/docs/ios/platform/introduction-to-ios8.md
@@ -56,9 +56,11 @@ HealthKit is a framework introduced in iOS 8 that provides a centralized, coordi
 For more information on using this in your Xamarin.iOS app, refer to the [Introduction to HealthKit](~/ios/platform/healthkit.md) guide.
 
 ## Extending iPhone Functionality
+
 With iOS8, developers are being given much more control over who can use their app, and increased capability for more open communication between third party apps. Features such as App Extensions and Document Picker open a world of possibilities for how applications can be used in Apple’s ecosystem.
 
 ### App Extensions
+
 App Extensions, to oversimplify, are a way for third party apps to communicate with one another. To maintain high security standards and to uphold the integrity of the sandboxed apps, this communication doesn’t happen directly between applications. Instead, it is carried out by an *Extension* in the middle.
 
 The first step in creating an App Extension is to define the correct extension point—this is important in ensuring the behavior and availability of the correct APIs. To create an App Extension in Visual Studio for Mac, add it to an existing application by adding a new project to your solution.
@@ -105,6 +107,7 @@ Handoff works with iOS 8 and Yosemite, and requires an iCloud account to be logg
 For more information, please see our [Handoff](~/ios/platform/handoff.md) guide.
 
 ## Unified Storyboards
+
 iOS 8 includes a new simpler to use mechanism for creating the user interface—the unified storyboard. With a single storyboard to cover all of the different hardware screen sizes, fast and responsive views can be created in a true "design once, use many" style.
 
 Prior to iOS8, developers used `UIInterfaceOrientation` to distinguish between portrait and landscape modes, and `UIInterfaceIdiom` to distinguish between iOS devices. In iOS8 it is no longer necessary to create separate storyboards for iPhone and iPad devices—orientation and device are determined by using *Size Classes*.
@@ -121,6 +124,7 @@ If the two concepts are used together, the result is a 2 x 2 grid that defines t
 For more information about size classes, refer to the [Introduction to Unified Storyboards](~/ios/user-interface/storyboards/unified-storyboards.md).
 
 ## Photo Kit
+
 Photo Kit is a new framework that allows applications to query the system image library and create custom user interfaces to view and modify its contents. It includes a number of classes that represent image and video assets, as well as collections of assets such as albums and folders.
 
 For more information, please see our [PhotoKit](~/ios/platform/photokit.md) guide.
@@ -144,11 +148,13 @@ Sprite Kit, the 2D game framework from Apple, has some interesting new features 
 For more information, please see our [SpriteKit](~/ios/platform/gaming/spritekit.md) documentation.
 
 ## Other Changes
+
 As well as the major changes in iOS 8 that are described above, Apple has additionally updated many existing frameworks. These are detailed below:
 
 - **[Core Image](https://developer.apple.com/library/prerelease/ios/documentation/GraphicsImaging/Reference/CoreImagingRef/index.html#//apple_ref/doc/uid/TP40001171)** – Apple has expanded upon its image processing framework by adding better support for the detection of rectangular regions, and QR codes inside images. Mike Bluestein explores this in his blog post entitled [Image Detection in iOS 8](https://blog.xamarin.com/image-detection-in-ios-8/)
 
 ## Deprecated APIs
+
 With all the improvements made in iOS 8, a number of APIs have deprecated. Some of these are detailed below.
 
 - **[UIApplication](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UIApplication_Class/index.html#//apple_ref/occ/cl/UIApplication)** – The methods and properties used for registering remote notifications have deprecated. These are registerForRemoteNotificationTypes and enabledRemoteNotificationTypes.
@@ -157,6 +163,7 @@ With all the improvements made in iOS 8, a number of APIs have deprecated. Some 
 - **[UISearchDisplayController](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UISearchDisplayController_Class/index.html#//apple_ref/occ/cl/UISearchDisplayController)** – This has been replaced by UISearchController in iOS8.
 
 ## Summary
+
 In this article we looked at some of the new features introduced by Apple in iOS 8.
 
 ## Related Links

--- a/docs/ios/troubleshooting/questions/error-registerserviceport.md
+++ b/docs/ios/troubleshooting/questions/error-registerserviceport.md
@@ -12,9 +12,11 @@ ms.date: 04/03/2018
 # iOS Designer Error with RegisterServicePort
 
 ## Sample Error
+
 > System.AggregateException: One or more errors occured ---> System.SystemException: RegisterServicePort(com.xamarin.MTHosting.2a0b1, com.apple.PowerManagement.control): Kernel returned: -308 (-308): (ipc/mig) server died
 
 ## Explanation
+
 Errors with `RegisterServicePort` and similar error messages like above are commonly an issue with spyware/malware on the computer. Please consider the [comment on this bug report](https://bugzilla.xamarin.com/show_bug.cgi?id=21907#c4) for more information, along with the link to the [Apple forum discussion](https://discussions.apple.com/thread/5596008) on how to remove a possible infection. 
 
 To assist in diagnosing the issue, open up the macOS application **Console** and delete every file inside the **User diagnostic reports** section [https://screencast.com/t/y9i3NKcuMy](https://screencast.com/t/y9i3NKcuMy). Then start Visual Studio for Mac and try to use the designer. If any new log files appear in this section after the designer has failed to initialize, please save these for us to analyze.  

--- a/docs/ios/troubleshooting/questions/index.md
+++ b/docs/ios/troubleshooting/questions/index.md
@@ -14,24 +14,31 @@ ms.date: 03/21/2017
 ## General Questions
 
 ### [Can I use a Mac VM with Xamarin?](mac-vm.md)
+
 Yes, but only on Mac hardware.
 
 ### [How can I downgrade Xcode?](downgrade-xcode.md)
+
 This guide provides links to access previous versions of Xcode as well as the latest version.
 
 ### [Where can I set my iOS SDK Locations?](ios-sdk.md)
+
 For most users these are set to the proper locations automatically. This guide lists the default SDK locations and how to change them if needed.
 
 ### [How can I reenable developer options after updating iOS?](update-developer-options.md)
+
 An iOS bug may cause the developer options to disappear after updating iOS versions, this has been observed when switching to iOS 8.x. This guide describes how the options can be reenabled.
 
 ### [User Location not working in iOS 8](ios8-user-location.md)
+
 This guide tells you how to edit info.plist to enable User Location in iOS 8.
 
 ### [Where can I find the .dSYM file to symbolicate iOS crash logs?](symbolicate-ios-crash.md)
+
 This guide describes basic steps for symbolicating iOS crash logs to help with diagnosing crashes. It also links to additional resources for more advanced symbolication techniques & info on interpreting iOS crash logs.
 
 ### [How do I set Mono Runtime environment variables for iOS projects in Xamarin Studio?](xs-mono-runtime.md)
+
 If you need to set any runtime environment variables for Mono, they can be set in the **Project Options > Run > General** page.
 
 ## Publishing Questions
@@ -42,35 +49,45 @@ Submitting apps that _require_ bitcode, such as watchOS and tvOS apps,
 must be done with Xcode 9.
 
 ### [Can I change the output path of the IPA file?](ipa-output-path.md)
+
 As of Xamarin Cycle 7, you can use customized MSBuild targets to achieve this.
 
 ### [How can I copy IPA output files to the TFS drop folder?](ipa-tfs.md)
+
 Yes, this guide describes how.
 
 ### [Can I add files to or remove files from an IPA file after building it in Visual Studio?](modify-ipa.md)
+
 Yes, it is possible but it will usually require that you re-sign the `.app` bundle after making the change. Note that modifying the `.ipa` file is not necessary in normal use. This article is provided purely for informational purposes.
 
 ### [Is it possible to create a .xcarchive archive from Visual Studio?](create-xcarchive.md)
+
 As of Xamarin 4, it is now possible to create a `.xcarchive` from Windows by setting the `ArchiveOnBuild` property to `true`.
 
 ### [Why does my app submission fail with: "Disallowed paths ( "iTunesMetadata.plist" ) found at ..." ?](itunesmetadata-disallowed-paths.md)
+
 This error is the result of a change in Apple's App Store verification process. This specific error is _not_ related to the particular version of Xamarin you have installed, so downgrading will _not_ help. This guide links to more information on how to fix the issue.
 
 ## Diagnosing Specific Error Messages
 
 ### [iOS Designer Error with RegisterServicePort](error-registerserviceport.md)
+
 Errors with `RegisterServicePort` and similar error messages like above are commonly an issue with spyware/malware on the computer. This guide details confirming the diagnosis and info on removing the spyware/malware.
 
 ### [Why does my iOS build fail with: no valid iPhone code signing keys found in keychain?](no-codesigning-keys.md)
+
 This error message occurs when the project in question is looking for valid code-signing credentials but are unable to find them. Code signing is required for testing and deployments on physical iOS devices; as well as Ad-hoc & App store builds.
 
 ### [Why does my iOS 9 app fail with: System.Exception: Failed to marshal the Objective-C object?](exception-marshal-obj-c.md)
+
 API changes in iOS 9 require that a callback constructor be used when calling unmanaged code, as the underlying API now expects it.
 
 ### [Runtime error: The assembly mscorlib.dll was not found or could not be loaded](error-mscorlib-not-found.md)
+
 This issue occurs when the *hidden* `.monotouch-32` and `.monotouch-64` folders are missing from the `.xcarchive` for signing / IPA creation, triggering the runtime error.
 
 ### [Compile error: Can not encode offset X in resulting scattered relocation](error-encode-offset-scattered-relocation.md)
+
 This issue occurs when building for 32-bit architectures, such as ARMv7, when the final binary is too large for the native toolchain.
 
 ## Deprecated
@@ -79,16 +96,21 @@ This issue occurs when building for 32-bit architectures, such as ARMv7, when th
 > The articles below apply to issues that have been resolved in recent versions of Xamarin. However, if the issue occurs on the latest version of the software, please file a [new bug](~/cross-platform/troubleshooting/questions/howto-file-bug.md) with your full versioning information and full build log output.
 
 ### [IPA file is 0 bytes](ipa-zero-bytes.md)
+
 There were some known issues in previous versions of Xamarin that could cause the IPA file on Windows to be 0 bytes.
 
 ### [IBTool Error: The operation couldn’t be completed.](error-ibtool.md)
+
 Apple [fixed](https://developer.apple.com/library/ios/releasenotes/DeveloperTools/RN-Xcode/Chapters/xc6_release_notes.html) this `ibtool` bug in Xcode 6.1.1, so upgrading to Xcode 6.1.1 or higher is the easiest fix.
 
 ### [Error MT1009: Could not copy the assembly](error-mt1009.md)
+
 This affects users running Xamarin.iOS 7.2.6. This issue is due to file permissions needing higher privileges when Xamarin.iOS is installed with a different user account then the developer's main account.
 
 ### [System.Exception AMDeviceNotificationSubscribe returned ...](exception-amddevicenotificationsubscribe.md)
+
 This message can appear in an error dialog when you first start Visual Studio for Mac, or in the `mtbserver.log` file. Note that this is an uncommon problem. If Visual Studio is having trouble connecting to the Mac build host, there are other errors that are more likely to appear in the `mtbserver.log` file.
 
 ### [MDocArchiveToMsxDocConverter.exe not found rver.BaseCommand.OnRequest](mdocarchivetomsxdocconverter-not-found.md)
+
 This error may appear in the `Mac Server Log` in Visual Studio.

--- a/docs/ios/troubleshooting/questions/ipa-output-path.md
+++ b/docs/ios/troubleshooting/questions/ipa-output-path.md
@@ -12,6 +12,7 @@ ms.date: 03/21/2017
 # Can I change the output path of the IPA file?
 
 ## For Cycle 7 and higher
+
 Yes, you can use customized MSBuild targets to achieve this. The easiest option is probably to copy the `.ipa` file after it has been built.
 
 These steps will work for any iOS project that uses the MSBuild build engine on either Mac or Windows. (Note: all Unified API projects use the MSBuild build engine.)

--- a/docs/ios/troubleshooting/questions/mac-vm.md
+++ b/docs/ios/troubleshooting/questions/mac-vm.md
@@ -12,9 +12,11 @@ ms.date: 04/03/2018
 # Can I use a Mac VM with Xamarin? 
 
 ## Mac Hardware
+
 Yes; be careful to follow Apple's terms of use.
 
 ## Non-Mac Hardware
+
 No; Apple's terms of use do not permit this usage.
 
 ### See Also

--- a/docs/ios/troubleshooting/questions/no-codesigning-keys.md
+++ b/docs/ios/troubleshooting/questions/no-codesigning-keys.md
@@ -43,4 +43,5 @@ You can workaround the issue by removing the `<CodesignEntitlements>` flag from 
 5. Reload the project and you should be able to deploy to the simulator.
 
 ### Next Steps
+
 For further assistance, to contact us, or if this issue remains even after utilizing the above information, please see [What support options are available for Xamarin?](~/cross-platform/troubleshooting/support-options.md) for information on contact options, suggestions, as well as how to file a new bug if needed.

--- a/docs/ios/user-interface/controls/uicollectionview.md
+++ b/docs/ios/user-interface/controls/uicollectionview.md
@@ -160,6 +160,7 @@ As with other parts of iOS, such as `UITableView` and `MKMapView`, `UICollection
 - **Number of items per section** – Returned from  `GetItemsCount` method.
 
 ### UICollectionViewController
+
 For convenience, the `UICollectionViewController` class is
 available.This is automatically configured to be both the delegate, which is
 discussed in the next section, and data source for its `UICollectionView` view.

--- a/docs/ios/user-interface/designer/introduction.md
+++ b/docs/ios/user-interface/designer/introduction.md
@@ -338,6 +338,7 @@ These controls adjust the zoom on the design surface. They do not affect the use
 Use the **Properties Pad** to edit the identity, visual styles, accessibility, and behavior of a control. The following screenshot illustrates the **Properties Pad** options for a button:
 
 [![The Properties Pad for a button](introduction-images/17-buttonpropertiespad-vsmac.png "The Properties Pad for a button")](introduction-images/17-buttonpropertiespad-vsmac-large.png#lightbox)
+
 #### Properties Pad sections
 
 The **Properties Pad** contains three sections:

--- a/docs/tools/ci/jenkins-walkthrough.md
+++ b/docs/tools/ci/jenkins-walkthrough.md
@@ -292,6 +292,7 @@ Polling SCM is a popular trigger because it provides quick feedback when a devel
 Periodic builds are often used to create a version of the application that can be distributed to testers. For example, a periodic build might be scheduled for Friday evening so that members of the QA team can test the work of the previous week.
 
 ### Compiling a Xamarin.iOS Applications
+
 Xamarin.iOS projects can be compiled at the command line using `xbuild` or `msbuild`. The shell command will execute in the context of the user account that is running Jenkins. It is important that the user account has access to the provisioning profile so that the application can be properly packaged for distribution. It is possible to add this shell command to the job configuration page.
 
 Scroll down to the **Build** section. Click the **Add build step** button and select **Execute shell**, as illustrated by the following screenshot:

--- a/docs/xamarin-forms/TOC.md
+++ b/docs/xamarin-forms/TOC.md
@@ -1,412 +1,821 @@
 # [Xamarin.Forms](index.yml)
+
 ## [Get Started](~/get-started/index.yml)
+
 ### [What is Xamarin.Forms](~/get-started/what-is-xamarin-forms.md)
+
 ### [Requirements](~/get-started/requirements.md)
+
 ### [Installation](~/get-started/installation/index.md)
+
 ### [Build your first app](~/get-started/first-app/index.md)
+
 ### [Single page quickstart](~/get-started/quickstarts/single-page.md)
+
 ### [Multi-page quickstart](~/get-started/quickstarts/multi-page.md)
+
 ### [Local database quickstart](~/get-started/quickstarts/database.md)
+
 ### [Styling quickstart](~/get-started/quickstarts/styling.md)
+
 ### [Deep dive](~/get-started/quickstarts/deepdive.md)
+
 ## XAML
+
 ### [Overview](xaml/index.yml)
+
 ### [XAML Basics](xaml/xaml-basics/index.md)
+
 #### [Part 1. Get Started with XAML](xaml/xaml-basics/get-started-with-xaml.md)
+
 #### [Part 2. Essential XAML Syntax](xaml/xaml-basics/essential-xaml-syntax.md)
+
 #### [Part 3. XAML Markup Extensions](xaml/xaml-basics/xaml-markup-extensions.md)
+
 #### [Part 4. Data Binding Basics](xaml/xaml-basics/data-binding-basics.md)
+
 #### [Part 5. From Data Bindings to MVVM](xaml/xaml-basics/data-bindings-to-mvvm.md)
+
 ### [XAML Controls](xaml/xaml-controls.md)
+
 ### [XAML Compilation](xaml/xamlc.md)
+
 ### [XAML Markup Extensions](xaml/markup-extensions/index.md)
+
 #### [Consuming XAML Markup Extensions](xaml/markup-extensions/consuming.md)
+
 #### [Creating XAML Markup Extensions](xaml/markup-extensions/creating.md)
+
 ### Tooling
+
 #### [XAML Hot Reload](xaml/hot-reload.md)
+
 #### [XAML Toolbox](xaml/toolbox.md)
+
 #### [XAML Previewer](xaml/xaml-previewer/index.md)
+
 ##### [Design-time data](xaml/xaml-previewer/design-time-data.md)
+
 ##### [Custom controls](xaml/xaml-previewer/render-custom-controls.md)
+
 ### Namespaces
+
 #### [XAML Namespaces](xaml/namespaces.md)
+
 #### [XAML Custom Namespace Schemas](xaml/custom-namespace-schemas.md)
+
 #### [XAML Namespace Recommended Prefixes](xaml/custom-prefix.md)
+
 ### Additional Capabilities
+
 #### [Bindable Properties](xaml/bindable-properties.md)
+
 #### [Attached Properties](xaml/attached-properties.md)
+
 #### [Resource Dictionaries](xaml/resource-dictionaries.md)
+
 #### [Passing Arguments](xaml/passing-arguments.md)
+
 #### [Field Modifiers](xaml/field-modifiers.md)
+
 #### [Loading XAML at Runtime](xaml/runtime-load.md)
+
 ## Application Fundamentals
+
 ### [Overview](app-fundamentals/index.yml)
+
 ### [Accessibility](app-fundamentals/accessibility/index.md)
+
 #### [Automation Properties](app-fundamentals/accessibility/automation-properties.md)
+
 #### [Keyboard Accessibility](app-fundamentals/accessibility/keyboard.md)
+
 ### [App Class](app-fundamentals/application-class.md)
+
 ### [App Lifecycle](app-fundamentals/app-lifecycle.md)
+
 ### [Application Indexing and Deep Linking](app-fundamentals/deep-linking.md)
+
 ### [Behaviors](app-fundamentals/behaviors/index.md)
+
 #### [Introduction](app-fundamentals/behaviors/introduction.md)
+
 #### [Attached Behaviors](app-fundamentals/behaviors/attached.md)
+
 #### [Xamarin.Forms Behaviors](app-fundamentals/behaviors/creating.md)
+
 #### [Reusable Behaviors](app-fundamentals/behaviors/reusable/index.md)
+
 ##### [EffectBehavior](app-fundamentals/behaviors/reusable/effect-behavior.md)
+
 ##### [EventToCommandBehavior](app-fundamentals/behaviors/reusable/event-to-command-behavior.md)
+
 ### [Custom Renderers](app-fundamentals/custom-renderer/index.md)
+
 #### [Introduction](app-fundamentals/custom-renderer/introduction.md)
+
 #### [Renderer Base Classes and Native Controls](app-fundamentals/custom-renderer/renderers.md)
+
 #### [Customizing an Entry](app-fundamentals/custom-renderer/entry.md)
+
 #### [Customizing a ContentPage](app-fundamentals/custom-renderer/contentpage.md)
+
 #### [Customizing a Map](app-fundamentals/custom-renderer/map/index.md)
+
 ##### [Customizing a Map Pin](app-fundamentals/custom-renderer/map/customized-pin.md)
+
 ##### [Highlighting a Circular Area on a Map](app-fundamentals/custom-renderer/map/circle-map-overlay.md)
+
 #### [Customizing a ListView](app-fundamentals/custom-renderer/listview.md)
+
 #### [Customizing a ViewCell](app-fundamentals/custom-renderer/viewcell.md)
+
 #### [Implementing a View](app-fundamentals/custom-renderer/view.md)
+
 #### [Implementing a HybridWebView](app-fundamentals/custom-renderer/hybridwebview.md)
+
 #### [Implementing a Video Player](app-fundamentals/custom-renderer/video-player/index.md)
+
 ##### [Creating the Platform Video Players](app-fundamentals/custom-renderer/video-player/player-creation.md)
+
 ##### [Playing a Web Video](app-fundamentals/custom-renderer/video-player/web-videos.md)
+
 ##### [Binding Video Sources to the Player](app-fundamentals/custom-renderer/video-player/source-bindings.md)
+
 ##### [Loading Application Resource Videos](app-fundamentals/custom-renderer/video-player/loading-resources.md)
+
 ##### [Accessing the Device's Video Library](app-fundamentals/custom-renderer/video-player/accessing-library.md)
+
 ##### [Custom Video Transport Controls](app-fundamentals/custom-renderer/video-player/custom-transport.md)
+
 ##### [Custom Video Positioning](app-fundamentals/custom-renderer/video-player/custom-positioning.md)
+
 ### [Data Binding](app-fundamentals/data-binding/index.md)
+
 #### [Basic Bindings](app-fundamentals/data-binding/basic-bindings.md)
+
 #### [Binding Mode](app-fundamentals/data-binding/binding-mode.md)
+
 #### [String Formatting](app-fundamentals/data-binding/string-formatting.md)
+
 #### [Binding Path](app-fundamentals/data-binding/binding-path.md)
+
 #### [Binding Value Converters](app-fundamentals/data-binding/converters.md)
+
 #### [Relative Bindings](app-fundamentals/data-binding/relative-bindings.md)
+
 #### [Binding Fallbacks](app-fundamentals/data-binding/binding-fallbacks.md)
+
 #### [The Command Interface](app-fundamentals/data-binding/commanding.md)
+
 #### [Compiled Bindings](app-fundamentals/data-binding/compiled-bindings.md)
+
 ### [DependencyService](app-fundamentals/dependency-service/index.md)
+
 #### [Introduction](app-fundamentals/dependency-service/introduction.md)
+
 #### [Registration and Resolution](app-fundamentals/dependency-service/registration-and-resolution.md)
+
 #### [Picking from the Photo Library](app-fundamentals/dependency-service/photo-picker.md)
+
 ### [Effects](app-fundamentals/effects/index.md)
+
 #### [Introduction](app-fundamentals/effects/introduction.md)
+
 #### [Effect Creation](app-fundamentals/effects/creating.md)
+
 #### [Passing Parameters](app-fundamentals/effects/passing-parameters/index.md)
+
 ##### [Parameters as CLR Properties](app-fundamentals/effects/passing-parameters/clr-properties.md)
+
 ##### [Parameters as Attached Properties](app-fundamentals/effects/passing-parameters/attached-properties.md)
+
 #### [Invoking Events](app-fundamentals/effects/touch-tracking.md)
+
 ### [Gestures](app-fundamentals/gestures/index.md)
+
 #### [Tap](app-fundamentals/gestures/tap.md)
+
 #### [Pinch](app-fundamentals/gestures/pinch.md)
+
 #### [Pan](app-fundamentals/gestures/pan.md)
+
 #### [Swipe](app-fundamentals/gestures/swipe.md)
+
 ### [Local Notifications](app-fundamentals/local-notifications.md)
+
 ### [Localization](app-fundamentals/localization/index.md)
+
 #### [String and Image Localization](app-fundamentals/localization/text.md)
+
 #### [Right-to-Left Localization](app-fundamentals/localization/right-to-left.md)
+
 ### [MessagingCenter](app-fundamentals/messaging-center.md)
+
 ### [Navigation](app-fundamentals/navigation/index.md)
+
 #### [Hierarchical Navigation](app-fundamentals/navigation/hierarchical.md)
+
 #### [TabbedPage](app-fundamentals/navigation/tabbed-page.md)
+
 #### [CarouselPage](app-fundamentals/navigation/carousel-page.md)
+
 #### [MasterDetailPage](app-fundamentals/navigation/master-detail-page.md)
+
 #### [Modal Pages](app-fundamentals/navigation/modal.md)
+
 ### [Shell](app-fundamentals/shell/index.md)
+
 #### [Introduction](app-fundamentals/shell/introduction.md)
+
 #### [Create a Shell application](app-fundamentals/shell/create.md)
+
 #### [Flyout](app-fundamentals/shell/flyout.md)
+
 #### [Tabs](app-fundamentals/shell/tabs.md)
+
 #### [Page configuration](app-fundamentals/shell/configuration.md)
+
 #### [Navigation](app-fundamentals/shell/navigation.md)
+
 #### [Search](app-fundamentals/shell/search.md)
+
 #### [Lifecycle](app-fundamentals/shell/lifecycle.md)
+
 #### [Custom Renderers](app-fundamentals/shell/customrenderers.md)
+
 ### [Templates](app-fundamentals/templates/index.md)
+
 #### [Control Templates](app-fundamentals/templates/control-templates/index.md)
+
 ##### [Introduction](app-fundamentals/templates/control-templates/introduction.md)
+
 ##### [Control Template Creation](app-fundamentals/templates/control-templates/creating.md)
+
 ##### [Template Bindings](app-fundamentals/templates/control-templates/template-binding.md)
+
 #### [Data Templates](app-fundamentals/templates/data-templates/index.md)
+
 ##### [Introduction](app-fundamentals/templates/data-templates/introduction.md)
+
 ##### [Data Template Creation](app-fundamentals/templates/data-templates/creating.md)
+
 ##### [Data Template Selection](app-fundamentals/templates/data-templates/selector.md)
+
 ### [Triggers](app-fundamentals/triggers.md)
+
 ## User Interface
+
 ### [Overview](user-interface/index.yml)
+
 ### [Activity Indicator](user-interface/activityindicator.md)
+
 ### [Animation](user-interface/animation/index.md)
+
 #### [Simple Animations](user-interface/animation/simple.md)
+
 #### [Easing Functions](user-interface/animation/easing.md)
+
 #### [Custom Animations](user-interface/animation/custom.md)
+
 ### [BoxView](user-interface/boxview.md)
+
 ### [Button](user-interface/button.md)
+
 ### [CarouselView](user-interface/carouselview/index.md)
+
 #### [Introduction](user-interface/carouselview/introduction.md)
+
 #### [Data](user-interface/carouselview/populate-data.md)
+
 #### [Layout](user-interface/carouselview/layout.md)
+
 #### [Interaction](user-interface/carouselview/interaction.md)
+
 #### [EmptyView](user-interface/carouselview/emptyview.md)
+
 #### [Scrolling](user-interface/carouselview/scrolling.md)
+
 ### [CheckBox](user-interface/checkbox.md)
+
 ### [CollectionView](user-interface/collectionview/index.md)
+
 #### [Introduction](user-interface/collectionview/introduction.md)
+
 #### [Data](user-interface/collectionview/populate-data.md)
+
 #### [Layout](user-interface/collectionview/layout.md)
+
 #### [Selection](user-interface/collectionview/selection.md)
+
 #### [EmptyView](user-interface/collectionview/emptyview.md)
+
 #### [Scrolling](user-interface/collectionview/scrolling.md)
+
 #### [Grouping](user-interface/collectionview/grouping.md)
+
 ### [Colors](user-interface/colors.md)
+
 ### [Controls reference](user-interface/controls/index.md)
+
 #### [Pages](user-interface/controls/pages.md)
+
 #### [Layouts](user-interface/controls/layouts.md)
+
 #### [Views](user-interface/controls/views.md)
+
 #### [Cells](user-interface/controls/cells.md)
+
 #### [Common properties, methods, and events](user-interface/controls/common-properties.md)
+
 #### [Third-Party Controls](user-interface/controls/thirdparty.md)
+
 ### [DataPages](user-interface/datapages/index.md)
+
 #### [Get Started](user-interface/datapages/get-started.md)
+
 #### [Controls Reference](user-interface/datapages/controls.md)
+
 ### [DatePicker](user-interface/datepicker.md)
+
 ### [Display Pop-Ups](user-interface/pop-ups.md)
+
 ### [Graphics with SkiaSharp](user-interface/graphics/skiasharp/index.md)
+
 ### [Images](user-interface/images.md)
+
 ### [ImageButton](user-interface/imagebutton.md)
+
 ### Layouts
+
 #### [Overview](user-interface/layouts/index.yml)
+
 #### [Choose a Layout](user-interface/layouts/choose-layout.md)
+
 #### [StackLayout](user-interface/layouts/stack-layout.md)
+
 #### [Grid](user-interface/layouts/grid.md)
+
 #### [FlexLayout](user-interface/layouts/flex-layout.md)
+
 #### [RelativeLayout](user-interface/layouts/relative-layout.md)
+
 #### [AbsoluteLayout](user-interface/layouts/absolute-layout.md)
+
 #### [ScrollView](user-interface/layouts/scroll-view.md)
+
 #### [ContentView](user-interface/layouts/contentview.md)
+
 #### [Frame](user-interface/layouts/frame.md)
+
 #### [LayoutOptions](user-interface/layouts/layout-options.md)
+
 #### [Margin and Padding](user-interface/layouts/margin-and-padding.md)
+
 #### [Device Orientation](user-interface/layouts/device-orientation.md)
+
 #### [Tablet & Desktop](user-interface/layouts/tablet.md)
+
 #### [Bindable Layouts](user-interface/layouts/bindable-layouts.md)
+
 #### [Layout Compression](user-interface/layouts/layout-compression.md)
+
 #### [Custom Layout](user-interface/layouts/custom.md)
+
 ### [ListView](user-interface/listview/index.md)
+
 #### [Data Sources](user-interface/listview/data-and-databinding.md)
+
 #### [Cell Appearance](user-interface/listview/customizing-cell-appearance.md)
+
 #### [List Appearance](user-interface/listview/customizing-list-appearance.md)
+
 #### [Interactivity](user-interface/listview/interactivity.md)
+
 #### [Performance](user-interface/listview/performance.md)
+
 ### Map
+
 #### [Initialization and Configuration](user-interface/map/index.md)
+
 #### [Pins](user-interface/map/pins.md)
+
 #### [Polygons and Polylines](user-interface/map/polygons.md)
+
 #### [Geocoding](user-interface/map/geocoder.md)
+
 ### [MenuItem](user-interface/menuitem.md)
+
 ### [Picker](user-interface/picker/index.md)
+
 #### [Setting a Picker's ItemsSource Property](user-interface/picker/populating-itemssource.md)
+
 #### [Adding Data to a Picker's Items Collection](user-interface/picker/populating-items.md)
+
 ### [ProgressBar](user-interface/progressbar.md)
+
 ### [RefreshView](user-interface/refreshview.md)
+
 ### [SearchBar](user-interface/searchbar.md)
+
 ### [Slider](user-interface/slider.md)
+
 ### [Splash Screen](user-interface/splashscreen.md)
+
 ### [Stepper](user-interface/stepper.md)
+
 ### [Styles](user-interface/styles/index.md)
+
 #### [Styling Xamarin.Forms Apps using XAML Styles](user-interface/styles/xaml/index.md)
+
 ##### [Introduction](user-interface/styles/xaml/introduction.md)
+
 ##### [Explicit Styles](user-interface/styles/xaml/explicit.md)
+
 ##### [Implicit Styles](user-interface/styles/xaml/implicit.md)
+
 ##### [Global Styles](user-interface/styles/xaml/application.md)
+
 ##### [Style Inheritance](user-interface/styles/xaml/inheritance.md)
+
 ##### [Dynamic Styles](user-interface/styles/xaml/dynamic.md)
+
 ##### [Device Styles](user-interface/styles/xaml/device.md)
+
 ##### [Style Classes](user-interface/styles/xaml/style-class.md)
+
 #### [Styling Xamarin.Forms Apps using Cascading Style Sheets (CSS)](user-interface/styles/css/index.md)
+
 ### [Switch](user-interface/switch.md)
+
 ### [TableView](user-interface/tableview.md)
+
 ### [Text](user-interface/text/index.md)
+
 #### [Label](user-interface/text/label.md)
+
 #### [Entry](user-interface/text/entry.md)
+
 #### [Editor](user-interface/text/editor.md)
+
 #### [Fonts](user-interface/text/fonts.md)
+
 #### [Styles](user-interface/text/styles.md)
+
 ### [Theming](user-interface/theming.md)
+
 ### [TimePicker](user-interface/timepicker.md)
+
 ### [ToolbarItem](user-interface/toolbaritem.md)
+
 ### [Visual](user-interface/visual/index.md)
+
 #### [Material Visual](user-interface/visual/material-visual.md)
+
 #### [Create a Visual Renderer](user-interface/visual/create.md)
+
 ### [Visual State Manager](user-interface/visual-state-manager.md)
+
 ### [WebView](user-interface/webview.md)
+
 ## Platform Features
+
 ### [Overview](platform/index.yml)
+
 ### Android
+
 #### [Overview](platform/android/index.md)
+
 #### [AppCompat & Material Design](platform/android/appcompat-material-design.md)
+
 #### [Button Padding and Shadows](platform/android/button-padding-shadow.md)
+
 #### [Entry Input Method Editor Options](platform/android/entry-ime-options.md)
+
 #### [ImageButton Drop Shadows](platform/android/imagebutton-drop-shadow.md)
+
 #### [ListView Fast Scrolling](platform/android/listview-fast-scrolling.md)
+
 #### [NavigationPage Bar Height](platform/android/navigationpage-bar-height.md)
+
 #### [Page Lifecycle Events](platform/android/page-lifecycle-events.md)
+
 #### [Soft Keyboard Input Mode](platform/android/soft-keyboard-input-mode.md)
+
 #### [TabbedPage Page Swiping](platform/android/tabbedpage-page-swiping.md)
+
 #### [TabbedPage Page Transition Animations](platform/android/tabbedpage-transition-animations.md)
+
 #### [TabbedPage Toolbar Placement and Color](platform/android/tabbedpage-toolbar-placement-color.md)
+
 #### [ViewCell Context Actions](platform/android/viewcell-context-actions.md)
+
 #### [VisualElement Elevation](platform/android/visualelement-elevation.md)
+
 #### [VisualElement Legacy Color Mode](platform/android/legacy-color-mode.md)
+
 #### [WebView Mixed Content](platform/android/webview-mixed-content.md)
+
 #### [WebView Zoom](platform/android/webview-zoom-controls.md)
+
 ### iOS
+
 #### [Overview](platform/ios/index.md)
+
 #### [Accessibility Scaling for Named Font Sizes](platform/ios/named-font-size-scaling.md)
+
 #### [Cell Background Color](platform/ios/cell-background-color.md)
+
 #### [Entry Cursor Color](platform/ios/entry-cursor-color.md)
+
 #### [Entry Font Size](platform/ios/entry-font-size.md)
+
 #### [Formatting](platform/ios/formatting.md)
+
 #### [Modal Page Presentation Style](platform/ios/page-presentation-style.md)
+
 #### [Large Page Titles](platform/ios/page-large-title.md)
+
 #### [ListView Group Header Style](platform/ios/listview-group-header-style.md)
+
 #### [ListView Row Animations](platform/ios/listview-row-animations.md)
+
 #### [ListView Separator Style](platform/ios/listview-separator-style.md)
+
 #### [Main Thread Control Updates](platform/ios/main-thread-updates-ui.md)
+
 #### [NavigationPage Bar Separator](platform/ios/navigation-bar-separator.md)
+
 #### [NavigationPage Bar Text Color Mode](platform/ios/status-bar-text-color.md)
+
 #### [NavigationPage Bar Translucency](platform/ios/navigation-bar-translucent.md)
+
 #### [Page Home Indicator Visibility](platform/ios/page-home-indicator.md)
+
 #### [Page Status Bar Visibility](platform/ios/page-status-bar-visibility.md)
+
 #### [Picker Item Selection](platform/ios/picker-selection.md)
+
 #### [Safe Area Layout Guide](platform/ios/page-safe-area-layout.md)
+
 #### [ScrollView Content Touches](platform/ios/scrollview-content-touches.md)
+
 #### [Simultaneous Pan Gesture Recognition](platform/ios/application-pan-gesture.md)
+
 #### [Slider Thumb Tap](platform/ios/slider-thumb.md)
+
 #### [VisualElement Blur](platform/ios/visualelement-blur.md)
+
 #### [VisualElement Drop Shadows](platform/ios/visualelement-drop-shadow.md)
+
 #### [VisualElement Legacy Color Mode](platform/ios/legacy-color-mode.md)
+
 ### Windows
+
 #### [Overview](platform/windows/index.md)
+
 #### [InputView Reading Order](platform/windows/inputview-reading-order.md)
+
 #### [ListView SelectionMode](platform/windows/listview-selectionmode.md)
+
 #### [MasterDetailPage Navigation Bar](platform/windows/masterdetailpage-navigation-bar.md)
+
 #### [Page Toolbar Placement](platform/windows/page-toolbar-placement.md)
+
 #### [Platform Setup](platform/windows/installation/index.md)
+
 #### [RefreshView Pull Direction](platform/windows/refreshview-pulldirection.md)
+
 #### [SearchBar Spell Check](platform/windows/searchbar-spell-check.md)
+
 #### [TabbedPage Icons](platform/windows/tabbedpage-icons.md)
+
 #### [VisualElement Access Keys](platform/windows/visualelement-access-keys.md)
+
 #### [VisualElement Legacy Color Mode](platform/windows/legacy-color-mode.md)
+
 #### [WebView JavaScript Alerts](platform/windows/webview-javascript-alert.md)
+
 ### [Create Platform-Specifics](platform/platform-specifics/index.md)
+
 ### [Device Class](platform/device.md)
+
 ### [Native Forms](platform/native-forms.md)
+
 ### [Native Views](platform/native-views/index.md)
+
 #### [Native Views in XAML](platform/native-views/xaml.md)
+
 #### [Native Views in C#](platform/native-views/code.md)
+
 ### [Sign In with Apple](platform/sign-in-with-apple/index.md)
+
 #### [Setup for iOS](~/ios/platform/ios13/sign-in.md)
+
 #### [Setup for other platforms](platform/sign-in-with-apple/setup.md)
+
 #### [Use Sign In with Apple](platform/sign-in-with-apple/android-ios-sign-in.md)
+
 ### [Other Platforms](platform/other/index.md)
+
 #### [GTK#](platform/other/gtk.md)
+
 #### [Mac](platform/other/mac.md)
+
 #### [Tizen](platform/other/tizen.md)
+
 #### [WPF](platform/other/wpf.md)
+
 ## [Xamarin.Essentials](~/essentials/index.md?context=xamarin/xamarin-forms)
+
 ### [Get Started](~/essentials/get-started.md?context=xamarin/xamarin-forms)
+
 ### [Platform & Feature Support](~/essentials/platform-feature-support.md?context=xamarin/xamarin-forms)
+
 ### [Accelerometer](~/essentials/accelerometer.md?context=xamarin/xamarin-forms)
+
 ### [App Information](~/essentials/app-information.md?context=xamarin/xamarin-forms)
+
 ### [Barometer](~/essentials/barometer.md?context=xamarin/xamarin-forms)
+
 ### [Battery](~/essentials/battery.md?context=xamarin/xamarin-forms)
+
 ### [Clipboard](~/essentials/clipboard.md?context=xamarin/xamarin-forms)
+
 ### [Color Converters](~/essentials/color-converters.md?context=xamarin/xamarin-forms)
+
 ### [Compass](~/essentials/compass.md?context=xamarin/xamarin-forms)
+
 ### [Connectivity](~/essentials/connectivity.md?context=xamarin/xamarin-forms)
+
 ### [Detect Shake](~/essentials/detect-shake.md?context=xamarin/xamarin-forms)
+
 ### [Device Display Information](~/essentials/device-display.md?context=xamarin/xamarin-forms)
+
 ### [Device Information](~/essentials/device-information.md?context=xamarin/xamarin-forms)
+
 ### [Email](~/essentials/email.md?context=xamarin/xamarin-forms)
+
 ### [File System Helpers](~/essentials/file-system-helpers.md?context=xamarin/xamarin-forms)
+
 ### [Flashlight](~/essentials/flashlight.md?context=xamarin/xamarin-forms)
+
 ### [Geocoding](~/essentials/geocoding.md?context=xamarin/xamarin-forms)
+
 ### [Geolocation](~/essentials/geolocation.md?context=xamarin/xamarin-forms)
+
 ### [Gyroscope](~/essentials/gyroscope.md?context=xamarin/xamarin-forms)
+
 ### [Launcher](~/essentials/launcher.md?context=xamarin/xamarin-forms)
+
 ### [Magnetometer](~/essentials/magnetometer.md?context=xamarin/xamarin-forms)
+
 ### [Main Thread](~/essentials/main-thread.md?context=xamarin/xamarin-forms)
+
 ### [Maps](~/essentials/maps.md?context=xamarin/xamarin-forms)
+
 ### [Open Browser](~/essentials/open-browser.md?context=xamarin/xamarin-forms)
+
 ### [Orientation Sensor](~/essentials/orientation-sensor.md?context=xamarin/xamarin-forms)
+
 ### [Phone Dialer](~/essentials/phone-dialer.md?context=xamarin/xamarin-forms)
+
 ### [Platform Extensions(Size, Rect, Point)](~/essentials/platform-extensions.md?context=xamarin/xamarin-forms)
+
 ### [Preferences](~/essentials/preferences.md?context=xamarin/xamarin-forms)
+
 ### [Secure Storage](~/essentials/secure-storage.md?context=xamarin/xamarin-forms)
+
 ### [Share](~/essentials/share.md?context=xamarin/xamarin-forms)
+
 ### [SMS](~/essentials/sms.md?context=xamarin/xamarin-forms)
+
 ### [Text-to-Speech](~/essentials/text-to-speech.md?context=xamarin/xamarin-forms)
+
 ### [Unit Converters](~/essentials/unit-converters.md?context=xamarin/xamarin-forms)
+
 ### [Version Tracking](~/essentials/version-tracking.md?context=xamarin/xamarin-forms)
+
 ### [Vibrate](~/essentials/vibrate.md?context=xamarin/xamarin-forms)
+
 ### [Xamarin.Essentials release notes](https://docs.microsoft.com/xamarin/essentials/release-notes/)
+
 ### [Troubleshooting](~/essentials/troubleshooting.md?context=xamarin/xamarin-forms)
 
 ## Data & Azure Cloud Services
+
 ### [Overview](data-cloud/index.yml)
+
 ### Local data storage
+
 #### [Overview](data-cloud/data/index.md)
+
 #### [File Handling](data-cloud/data/files.md)
+
 #### [Local Databases](data-cloud/data/databases.md)
+
 ### Azure Services
+
 #### [Azure services overview](data-cloud/azure-services/index.md)
+
 #### [Azure Cosmos DB Document Database](data-cloud/azure-services/azure-cosmosdb.md)
+
 #### [Azure Notification Hubs](data-cloud/azure-services/azure-notification-hub.md)
+
 #### [Azure Storage](data-cloud/azure-services/azure-storage.md)
+
 #### [Azure Search](data-cloud/azure-services/azure-search.md)
+
 #### [Azure Functions](data-cloud/azure-services/azure-functions.md)
+
 #### [Azure SignalR Service](data-cloud/azure-services/azure-signalr.md)
+
 ### Azure Cognitive Services
+
 #### [Cognitive services overview](data-cloud/azure-cognitive-services/index.md)
+
 #### [Introduction](data-cloud/azure-cognitive-services/introduction.md)
+
 #### [Speech Recognition](data-cloud/azure-cognitive-services/speech-recognition.md)
+
 #### [Spell Check](data-cloud/azure-cognitive-services/spell-check.md)
+
 #### [Text Translation](data-cloud/azure-cognitive-services/text-translation.md)
+
 #### [Perceived Emotion Recognition](data-cloud/azure-cognitive-services/emotion-recognition.md)
+
 ### Web Services
+
 #### [Web services overview](data-cloud/web-services/index.md)
+
 #### [Introduction](data-cloud/web-services/introduction.md)
+
 #### [ASMX](data-cloud/web-services/asmx.md)
+
 #### [WCF](data-cloud/web-services/wcf.md)
+
 #### [REST](data-cloud/web-services/rest.md)
+
 ### Authentication
+
 #### [Authentication overview](data-cloud/authentication/index.md)
+
 #### [REST](data-cloud/authentication/rest.md)
+
 #### [OAuth](data-cloud/authentication/oauth.md)
+
 #### [Azure Active Directory B2C](data-cloud/authentication/azure-ad-b2c.md)
+
 #### [Azure Cosmos DB Authentication](data-cloud/authentication/azure-cosmosdb-auth.md)
+
 ## Deployment & Testing
+
 ### [Overview](deploy-test/index.yml)
+
 ### [Improve Performance](deploy-test/performance.md)
+
 ### [Automate Testing with Visual Studio App Center](/appcenter/test-cloud/uitest/get-started-xamarin-forms)
+
 ### [Publish iOS apps](~/ios/deploy-test/app-distribution/index.md)
+
 ### [Publish Android apps](~/android/deploy-test/publishing/index.md)
+
 ### [Publish UWP apps](/windows/uwp/packaging/)
+
 ### [Publish Mac apps](~/mac/deploy-test/publishing-to-the-app-store/index.md)
+
 ## Advanced Concepts and Internals
+
 ### [Overview](internals/index.yml)
+
 ### [Controls Class Hierarchy](internals/class-hierarchy.md)
+
 ### [Dependency Resolution](internals/dependency-resolution.md)
+
 ### [Fast Renderers](internals/fast-renderers.md)
+
 ### [.NET Standard](internals/net-standard.md)
+
 ### [Source Link](internals/sourcelink.md)
+
 ## [Troubleshooting](troubleshooting/index.md)
+
 ### [Frequently Asked Questions](troubleshooting/questions/index.md)
+
 #### [Can I update the Xamarin.Forms default template to a newer NuGet package?](troubleshooting/questions/update-forms-template.md)
+
 #### [Why doesn't the Visual Studio XAML designer work for Xamarin.Forms XAML files?](troubleshooting/questions/forms-xaml-designer.md)
+
 #### [Android build error: The "LinkAssemblies" task failed unexpectedly](troubleshooting/questions/android-linkassemblies-error.md)
+
 #### [Why does my Xamarin.Forms.Maps Android project fail with COMPILETODALVIK : UNEXPECTED TOP-LEVEL ERROR?](troubleshooting/questions/maps-compiletodalvik-error.md)
+
 ## [Release notes](https://docs.microsoft.com/xamarin/xamarin-forms/release-notes/)
+
 ## [Samples](samples/index.yml)
+
 ## [Creating Mobile Apps with Xamarin.Forms Book](creating-mobile-apps-xamarin-forms/index.md)
+
 ## [Enterprise Application Patterns eBook](enterprise-application-patterns/index.md)
+
 ## [SkiaSharp Graphics in Xamarin.Forms](user-interface/graphics/skiasharp/index.md)

--- a/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/TOC.md
+++ b/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/TOC.md
@@ -1,29 +1,57 @@
 # [Creating Mobile Apps with Xamarin.Forms Book](index.md)
+
 ## [1. How does Xamarin.Forms fit in?](summaries/chapter01.md)
+
 ## [2. Anatomy of an app](summaries/chapter02.md)
+
 ## [3. Deeper into text](summaries/chapter03.md)
+
 ## [4. Scrolling the stack](summaries/chapter04.md)
+
 ## [5. Dealing with sizes](summaries/chapter05.md)
+
 ## [6. Button clicks](summaries/chapter06.md)
+
 ## [7. XAML vs. code](summaries/chapter07.md)
+
 ## [8. Code and XAML in harmony](summaries/chapter08.md)
+
 ## [9. Platform-specific API calls](summaries/chapter09.md)
+
 ## [10. XAML markup extensions](summaries/chapter10.md)
+
 ## [11. The bindable infrastructure](summaries/chapter11.md)
+
 ## [12. Styles](summaries/chapter12.md)
+
 ## [13. Bitmaps](summaries/chapter13.md)
+
 ## [14. Absolute layout](summaries/chapter14.md)
+
 ## [15. The interative interface](summaries/chapter15.md)
+
 ## [16. Data binding](summaries/chapter16.md)
+
 ## [17. Mastering the Grid](summaries/chapter17.md)
+
 ## [18. MVVM](summaries/chapter18.md)
+
 ## [19. Collection views](summaries/chapter19.md)
+
 ## [20. Async and file I/O](summaries/chapter20.md)
+
 ## [21. Transforms](summaries/chapter21.md)
+
 ## [22. Animation](summaries/chapter22.md)
+
 ## [23. Triggers and behaviors](summaries/chapter23.md)
+
 ## [24. Page navigation](summaries/chapter24.md)
+
 ## [25. Page varieties](summaries/chapter25.md)
+
 ## [26. Custom layouts](summaries/chapter26.md)
+
 ## [27. Custom renderers](summaries/chapter27.md)
+
 ## [28. Location and maps](summaries/chapter28.md)

--- a/docs/xamarin-forms/data-cloud/web-services/wcf.md
+++ b/docs/xamarin-forms/data-cloud/web-services/wcf.md
@@ -222,6 +222,7 @@ The `Task.Factory.FromAsync` method creates a `Task` that executes the `TodoServ
 The web service throws a `FaultException` if it fails to locate or delete the `TodoItem`, which is handled by the application.
 
 ## Configure remote access to IIS Express
+
 In Visual Studio 2017 or Visual Studio 2019, you should be able to test the UWP application on a PC with no additional configuration. Testing Android and iOS clients may require the additional steps in this section. See [Connect to Local Web Services from iOS Simulators and Android Emulators](~/cross-platform/deploy-test/connect-to-local-web-services.md) for more information.
 
 By default, IIS Express will only respond to requests to `localhost`. Remote devices (such as an Android device, an iPhone or even a simulator) will not have access to your local WCF service. You will need to know your Windows 10 workstation IP address on the local network. For the purpose of this example, assume that your workstation has the IP address `192.168.1.143`. The following steps explain how to configure Windows 10 and IIS Express to accept remote connections and connect to the service from a physical or virtual device:

--- a/docs/xamarin-forms/troubleshooting/questions/index.md
+++ b/docs/xamarin-forms/troubleshooting/questions/index.md
@@ -12,13 +12,17 @@ ms.date: 04/25/2017
 # Xamarin.Forms Frequently Asked Questions
 
 ## [Can I update the Xamarin.Forms default template to a newer NuGet package?](update-forms-template.md)
+
 This guide uses the Xamarin.Forms .NET Standard library template as an example, but the same general method will also work for the Xamarin.Forms Shared Project template.
 
 ## [Why doesn't the Visual Studio XAML designer work for Xamarin.Forms XAML files?](forms-xaml-designer.md)
+
 Xamarin.Forms doesn't currently support visual designers for XAML files.
 
 ## [Android build error: The "LinkAssemblies" task failed unexpectedly](android-linkassemblies-error.md)
+
 You may see an error message `The "LinkAssemblies" task failed unexpectedly` when building a Xamarin.Android project that uses Forms. This happens when the linker is active (typically on a *Release* build to reduce the size of the app package); and it occurs because the Android targets aren't updated to the latest framework. 
 
 ## ["Why does my Xamarin.Forms.Maps Android project fail with COMPILETODALVIK : UNEXPECTED TOP-LEVEL ERROR?"](maps-compiletodalvik-error.md)
+
 This error may be seen in the Error pad of Visual Studio for Mac or in the Build Output window of Visual Studio; in Android projects using Xamarin.Forms.Maps. It is most commonly resolved by increasing the Java Heap Size for your Xamarin.Android project.

--- a/docs/xamarin-forms/user-interface/activityindicator.md
+++ b/docs/xamarin-forms/user-interface/activityindicator.md
@@ -10,6 +10,7 @@ ms.date: 07/10/2019
 ---
 
 # Xamarin.Forms ActivityIndicator
+
 [![Download Sample](~/media/shared/download.png) Download the sample](https://docs.microsoft.com/samples/xamarin/xamarin-forms-samples/userinterface-activityindicatordemos/)
 
 The Xamarin.Forms [`ActivityIndicator`](xref:Xamarin.Forms.ActivityIndicator) control displays an animation to show that the application is engaged in a lengthy activity. Unlike the [`ProgressBar`](xref:Xamarin.Forms.ProgressBar), the `ActivityIndicator` gives no indication of progress. The `ActivityIndicator` inherits from [`View`](xref:Xamarin.Forms.View).

--- a/docs/xamarin-forms/user-interface/layouts/relative-layout.md
+++ b/docs/xamarin-forms/user-interface/layouts/relative-layout.md
@@ -137,6 +137,7 @@ Views laid out by `RelativeLayout` have two options for specifying their size:
 `HeightRequest` and `WidthRequest` specify the intended height and width of the view, but may be overridden by layouts as needed. `WidthConstraint` and `HeightConstraint` support setting the height and width as a value relative to the layout's or another view's properties, or as a constant value.
 
 ## Exploring a Complex Layout
+
 Each of the layouts have strengths and weaknesses for creating particular layouts. Throughout this series of layout articles, a sample app has been created with the same page layout implemented using three different layouts.
 
 Consider the following XAML:

--- a/docs/xamarin-forms/user-interface/listview/customizing-cell-appearance.md
+++ b/docs/xamarin-forms/user-interface/listview/customizing-cell-appearance.md
@@ -16,6 +16,7 @@ ms.date: 09/12/2019
 The Xamarin.Forms [`ListView`](xref:Xamarin.Forms.ListView) class is used to present scrollable lists, which can be customized through the use of `ViewCell` elements. A `ViewCell` element can display text and images, indicate a true/false state, and receive user input.
 
 ## Built in Cells
+
 Xamarin.Forms comes with built-in cells that work for many applications:
 
 - [`TextCell`](#textcell) controls are used for displaying text with an optional second line for detail text.
@@ -61,6 +62,7 @@ The following screenshot shows `ImageCell` items with customized color propertie
 !["Customized ImageCell Example"](customizing-cell-appearance-images/image-cell-custom.png "Customized ImageCell Example")
 
 ## Custom Cells
+
 Custom cells allow you to create cell layouts that aren't supported by the built-in cells. For example, you may want to present a cell with two labels that have equal weight. A `TextCell` would be insufficient because the `TextCell` has one label that is smaller. Most cell customizations add additional read-only data (such as additional labels, images or other display information).
 
 All custom cells must derive from [`ViewCell`](xref:Xamarin.Forms.ViewCell), the same base class that all of the built-in cell types use.
@@ -72,6 +74,7 @@ The following screenshot shows an example of a custom cell:
 !["Custom Cell Example"](customizing-cell-appearance-images/custom-cell.png "Custom Cell Example")
 
 ### XAML
+
 The custom cell shown in the previous screenshot can be created with the following XAML:
 
 ```xaml

--- a/docs/xamarin-forms/user-interface/progressbar.md
+++ b/docs/xamarin-forms/user-interface/progressbar.md
@@ -10,6 +10,7 @@ ms.date: 07/09/2019
 ---
 
 # Xamarin.Forms ProgressBar
+
 [![Download Sample](~/media/shared/download.png) Download the sample](https://docs.microsoft.com/samples/xamarin/xamarin-forms-samples/userinterface-progressbardemos/)
 
 The Xamarin.Forms [`ProgressBar`](xref:Xamarin.Forms.ProgressBar) control visually represents progress as a horizontal bar that is filled to a percentage represented by a `float` value. The `ProgressBar` class inherits from [`View`](xref:Xamarin.Forms.View).

--- a/docs/xamarin-forms/xaml/live-reload.md
+++ b/docs/xamarin-forms/xaml/live-reload.md
@@ -23,6 +23,7 @@ Xamarin Live Reload enables you to **make changes to your XAML and see them refl
 * [Xamarin.Forms 3.0.0 or above](https://www.nuget.org/packages/Xamarin.Forms/).
 
 ## Getting Started
+
 ### 1. Install Xamarin Live Reload from the Visual Studio Marketplace
 
 Xamarin Live Reload is distributed via the Visual Studio Marketplace. To install the extension, visit the [Xamarin Live Reload page on the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Xamarin.XamarinLiveReload) website and click **Download**.
@@ -74,6 +75,7 @@ Compile and deploy your application. Once the app is the deployed, open a XAML f
 Live Reload works with changes to any XAML file. Changes to C# or adding/removing NuGet packages requires a new build and deploy to take effect.
 
 ## Frequently Asked Questions 
+
 ### Is Xamarin Live Reload available on Visual Studio for Mac? 
 
 No, preview release of Xamarin Live Reload is only available for Visual Studio 2017.

--- a/docs/xamarin-forms/xaml/xaml-previewer/render-custom-controls.md
+++ b/docs/xamarin-forms/xaml/xaml-previewer/render-custom-controls.md
@@ -42,13 +42,16 @@ Currently, SkiaSharp controls are only supported when you're previewing on iOS. 
 ## Troubleshooting
 
 ### Check your Xamarin.Forms version
+
 Make sure you have at least Xamarin.Forms 3.6 installed. You can update your Xamarin.Forms version on NuGet.
 
 ### Even with `[DesignTimeVisible(true)]`, my custom control isn't rendering properly.
+
 Custom controls that rely heavily on code-behind or backend data don't always work in the XAML Previewer. You can try:
 
 * Moving the control so it doesn't initialize if [design mode is enabled](index.md#detect-design-mode)
 * Setting up [design time data](design-time-data.md) to show fake data from the backend
 
 ### The XAML Previewer shows the error "Custom Controls aren't rendering properly"
+
 Try cleaning and rebuilding your project, or closing and reopening the XAML file.


### PR DESCRIPTION

Headings should be surrounded by blank lines.
Autocleanup with `markdownlint --fix  "**/*.md"`