### PR TITLE
Update MenuItem and ToolbarItem articles with instructions and examples to enable or disable

### DIFF
--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -192,6 +192,51 @@ public MenuItemXamlMvvmPage()
 
 For more information on using images in Xamarin.Forms, see [Images in Xamarin.Forms](~/xamarin-forms/user-interface/images.md).
 
+## Enable or disable a MenuItem at runtime
+
+To enable of disable a `MenuItem` at runtime, bind its `Command` property to an `ICommand` implementation, and ensure that a `canExecute` delegate enables and disables the `ICommand` as appropriate.
+
+> [!IMPORTANT]
+> Do not bind the `IsEnabled` property to another property when using the `Command` property to enable or disable the `MenuItem`.
+
+The following example shows a `MenuItem` whose `Command` property binds to an `ICommand` named `MyCommand`:
+
+```xaml
+<MenuItem Text="My menu item"
+          Command="{Binding MyCommand}" />
+```
+
+The `ICommand` implementation requires a `canExecute` delegate that returns the value of a `bool` property to enable and disable the `MenuItem`:
+
+```csharp
+public class MyViewModel : INotifyPropertyChanged
+{
+    bool isMenuItemEnabled = false;
+    public bool IsMenuItemEnabled
+    {
+        get { return isMenuItemEnabled; }
+        set
+        {
+            isMenuItemEnabled = value;
+            MyCommand.ChangeCanExecute();
+        }
+    }
+
+    public Command MyCommand { get; private set; }
+
+    public ToolbarItemViewModel()
+    {
+        MyCommand = new Command(() =>
+        {
+            // Execute logic here
+        },
+        () => IsToolbarItemEnabled);
+    }
+}
+```
+
+In this example, the `MenuItem` is disabled until the `IsMenuItemEnabled` property is set. When this occurs, the `Command.ChangeCanExecute` method is called which causes the `canExecute` delegate for `MyCommand` to be re-evaluated.
+
 ## Cross-platform context menu behavior
 
 Context menus are accessed and displayed differently on each platform.
@@ -207,55 +252,6 @@ On iOS, the context menu is activated by swiping on a list item. The context men
 On UWP, the context menu is activated by right-clicking on a list item. The context menu is displayed near the cursor as a vertical list.
 
 !["Screenshot of context menu on UWP"](menuitem-images/menuitem-uwp.png "Screenshot of context menu on UWP")
-
-## Enable or disable a MenuItem dynamically
-
-To dynamically manipulate whether a `MenuItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
-
-For example, for a `MenuItem` defined in XAML such as:
-
-```xaml
-<MenuItem Text="Add"
-          IconImageSource="icon.png"
-          Command="{Binding AddCommand}" />
-```
-
-Do not bind to the `IsEnabled` property if you are using the `Command` property to enable/disable the `MenuItem`, in order to ensure control of the state of the `MenuItem`.
-
-In the view model, implement the `AddCommand` with a `canExecute` delegate returning the value of a `bool` property called `Enabled`:
-
-```csharp
-public ViewModel : INotifyPropertyChanged
-{
-    public Command AddCommand { get; set; }
-    
-    // ...
-    
-    public ViewModel()
-    {
-        AddCommand = new Command(() =>
-            {
-                // your execute action code here
-            },
-            () => Enabled);
-    }
-    
-    // ...
-    
-    private bool _enabled; // default value is false, state will initially be disabled
-    public bool Enabled
-    {
-        get => _enabled;
-        set
-        {
-            _enabled = value;
-            AddCommand.ChangeCanExecute();
-        }
-    }
-}
-```
-
-To ensure that the menu item is enabled by default in this example, make sure that `Enabled` initially returns `true`. 
 
 ## Related links
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -211,7 +211,7 @@ On UWP, the context menu is activated by right-clicking on a list item. The cont
 
 !["Screenshot of context menu on UWP"](menuitem-images/menuitem-uwp.png "Screenshot of context menu on UWP")
 
-## Enable or Disable a MenuItem
+## Enable or disable a MenuItem
 
 To manipulate whether a `MenuItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -30,6 +30,9 @@ The `MenuItem` class defines the following properties:
 
 These properties are backed by [`BindableProperty`](xref:Xamarin.Forms.BindableProperty) objects so the `MenuItem` instance can be the target of data bindings.
 
+> [!NOTE]
+> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `ToolbarItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `CanExecute` functionality.
+
 ## Create a MenuItem
 
 `MenuItem` objects can be used within a context menu on a `ListView` object's items. The most common pattern is to create `MenuItem` objects within a `ViewCell` instance, which is used as the `DataTemplate` object for the `ListView`s `ItemTemplate`. When the `ListView` object is populated it will create each item using the `DataTemplate`, exposing the `MenuItem` choices when the context menu is activated for an item.

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -208,9 +208,9 @@ On UWP, the context menu is activated by right-clicking on a list item. The cont
 
 !["Screenshot of context menu on UWP"](menuitem-images/menuitem-uwp.png "Screenshot of context menu on UWP")
 
-## Enable or disable a MenuItem
+## Enable or disable a MenuItem dynamically
 
-To manipulate whether a `MenuItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
+To dynamically manipulate whether a `MenuItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
 
 For example, for a `MenuItem` defined in XAML such as:
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -31,7 +31,7 @@ The `MenuItem` class defines the following properties:
 These properties are backed by [`BindableProperty`](xref:Xamarin.Forms.BindableProperty) objects so the `MenuItem` instance can be the target of data bindings.
 
 > [!NOTE]
-> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `MenuItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter as a delegate that returns `true` or `false`. For an example, see [Enable or Disable a MenuItem](#enable-or-disable-a-menuitem) below.
+> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `MenuItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter as a delegate that returns `true` or `false`. For an example, see [Enable or disable a MenuItem](#enable-or-disable-a-menuitem) below.
 
 ## Create a MenuItem
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -31,7 +31,7 @@ The `MenuItem` class defines the following properties:
 These properties are backed by [`BindableProperty`](xref:Xamarin.Forms.BindableProperty) objects so the `MenuItem` instance can be the target of data bindings.
 
 > [!NOTE]
-> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `ToolbarItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `CanExecute` functionality.
+> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `ToolbarItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter to a delegate that returns `true` or `false`.
 
 ## Create a MenuItem
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -31,7 +31,7 @@ The `MenuItem` class defines the following properties:
 These properties are backed by [`BindableProperty`](xref:Xamarin.Forms.BindableProperty) objects so the `MenuItem` instance can be the target of data bindings.
 
 > [!NOTE]
-> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `ToolbarItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter to a delegate that returns `true` or `false`.
+> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `ToolbarItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter as a delegate that returns `true` or `false`.
 
 ## Create a MenuItem
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -30,9 +30,6 @@ The `MenuItem` class defines the following properties:
 
 These properties are backed by [`BindableProperty`](xref:Xamarin.Forms.BindableProperty) objects so the `MenuItem` instance can be the target of data bindings.
 
-> [!NOTE]
-> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `MenuItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter as a delegate that returns `true` or `false`. For an example, see [Enable or disable a MenuItem](#enable-or-disable-a-menuitem) below.
-
 ## Create a MenuItem
 
 `MenuItem` objects can be used within a context menu on a `ListView` object's items. The most common pattern is to create `MenuItem` objects within a `ViewCell` instance, which is used as the `DataTemplate` object for the `ListView`s `ItemTemplate`. When the `ListView` object is populated it will create each item using the `DataTemplate`, exposing the `MenuItem` choices when the context menu is activated for an item.
@@ -223,7 +220,7 @@ For example, for a `MenuItem` defined in XAML such as:
           Command="{Binding AddCommand}" />
 ```
 
-Do not bind to the `IsEnabled` property, in order to ensure control of the default state of the `MenuItem`.
+Do not bind to the `IsEnabled` property if you are using the `Command` property to enable/disable the `MenuItem`, in order to ensure control of the state of the `MenuItem`.
 
 In the view model, implement the `AddCommand` with a `canExecute` delegate returning the value of a `bool` property called `Enabled`:
 
@@ -258,7 +255,7 @@ public ViewModel : INotifyPropertyChanged
 }
 ```
 
-To ensure that the menu item is enabled by default, make sure that `Enabled` initially returns `true`. 
+To ensure that the menu item is enabled by default in this example, make sure that `Enabled` initially returns `true`. 
 
 ## Related links
 

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -245,7 +245,7 @@ public ViewModel : INotifyPropertyChanged
     
     // ...
     
-    private bool _enabled; // default value is false
+    private bool _enabled; // default value is false, state will initially be disabled
     public bool Enabled
     {
         get => _enabled;

--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -25,13 +25,13 @@ The `MenuItem` class defines the following properties:
 * [`CommandParameter`](xref:Xamarin.Forms.MenuItem.CommandParameter) is an `object` that specifies the parameter that should be passed to the `Command`.
 * [`IconImageSource`](xref:Xamarin.Forms.MenuItem.IconImageSource) is an `ImageSource` value that defines the display icon.
 * [`IsDestructive`](xref:Xamarin.Forms.MenuItem.IsDestructive) is a `bool` value that indicates whether the `MenuItem` removes its associated UI element from the list.
-* [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) is a `bool` value that determines whether this object responds to user input.
+* [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) is a `bool` value that indicates whether this object responds to user input.
 * [`Text`](xref:Xamarin.Forms.MenuItem.Text) is a `string` value that specifies the display text.
 
 These properties are backed by [`BindableProperty`](xref:Xamarin.Forms.BindableProperty) objects so the `MenuItem` instance can be the target of data bindings.
 
 > [!NOTE]
-> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `ToolbarItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter as a delegate that returns `true` or `false`.
+> The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) bindable property is read-only. To manipulate the enabled/disabled state of a `MenuItem`, bind the `Command` property to a class that implements `ICommand` and implement the Command's `canExecute` parameter as a delegate that returns `true` or `false`. For an example, see [Enable or Disable a MenuItem](#enable-or-disable-a-menuitem) below.
 
 ## Create a MenuItem
 
@@ -210,6 +210,55 @@ On iOS, the context menu is activated by swiping on a list item. The context men
 On UWP, the context menu is activated by right-clicking on a list item. The context menu is displayed near the cursor as a vertical list.
 
 !["Screenshot of context menu on UWP"](menuitem-images/menuitem-uwp.png "Screenshot of context menu on UWP")
+
+## Enable or Disable a MenuItem
+
+To manipulate whether a `MenuItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
+
+For example, for a `MenuItem` defined in XAML such as:
+
+```xaml
+<MenuItem Text="Add"
+          IconImageSource="icon.png"
+          Command="{Binding AddCommand}" />
+```
+
+Do not bind to the `IsEnabled` property, in order to ensure control of the default state of the `MenuItem`.
+
+In the view model, implement the `AddCommand` with a `canExecute` delegate returning the value of a `bool` property called `Enabled`:
+
+```csharp
+public ViewModel : INotifyPropertyChanged
+{
+    public Command AddCommand { get; set; }
+    
+    // ...
+    
+    public ViewModel()
+    {
+        AddCommand = new Command(() =>
+            {
+                // your execute action code here
+            },
+            () => Enabled);
+    }
+    
+    // ...
+    
+    private bool _enabled; // default value is false
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            _enabled = value;
+            AddCommand.ChangeCanExecute();
+        }
+    }
+}
+```
+
+To ensure that the menu item is enabled by default, make sure that `Enabled` initially returns `true`. 
 
 ## Related links
 

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -120,7 +120,7 @@ For example, create a `ToolbarItem` on a `ContentPage` and bind its `Command` pr
 
 ```xaml
 <ContentPage.ToolbarItems>
-    <ToolbarItem Command="{Binding ToolbarTappedCommand}" Icon="enabled" />
+    <ToolbarItem Command="{Binding ToolbarTappedCommand}" Icon="icon.png" />
 </ContentPage.ToolbarItems>
 ```
 

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -114,7 +114,7 @@ When the `Order` property is set to `Secondary`, behavior varies across platform
 
 ## Enable or disable a ToolbarItem
 
-The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) property inherited from [`MenuItem`](xref:Xamarin.Forms.MenuItem) is read-only, and should not be used to manipulate the enabled or disabled state of a `ToolbarItem`. Instead, use the `CanExecute` functionality of the command bound to the `Command` property of the `ToolbarItem`.
+To manipulate whether a `ToolbarItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
 
 For example, create a `ToolbarItem` on a `ContentPage` and bind its `Command` property in XAML:
 
@@ -153,7 +153,7 @@ public class ViewModel : INotifyPropertyChanged
     }
 ```
 
-The `Enabled` property's default return value of `false` will initially set the `ToolbarItem` as disabled.
+In this example, the `Enabled` property's default return value of `false` will initially set the `ToolbarItem` as disabled. Setting it to an initial value of `true` will initially enable the `ToolbarItem`.
 
 ## Related links
 

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -112,7 +112,7 @@ When the `Order` property is set to `Secondary`, behavior varies across platform
 > [!WARNING]
 > Icon behavior in `ToolbarItem` objects that have their `Order` property set to `Secondary` is inconsistent across platforms. Avoid setting the `IconImageSource` property on items that appear in the secondary menu.
 
-## Enable or Disable a ToolbarItem
+## Enable or disable a ToolbarItem
 
 The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) property inherited from [`MenuItem`](xref:Xamarin.Forms.MenuItem) is read-only, and should not be used to manipulate the enabled or disabled state of a `ToolbarItem`. Instead, use the `CanExecute` functionality of the command bound to the `Command` property of the `ToolbarItem`.
 

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -124,7 +124,7 @@ For example, create a `ToolbarItem` on a `ContentPage` and bind its `Command` pr
 </ContentPage.ToolbarItems>
 ```
 
-In the view model, when implementing the `Command`, set a delegate for its `canExecute` parameter to a property returning `bool` indicating whether to enable (`true`) or disable (`false`) the `ToolbarItem`:
+In the view model, when implementing the `Command`, set a delegate for its `canExecute` parameter to return a `bool` property indicating whether to enable (`true`) or disable (`false`) the `ToolbarItem`:
 
 ```csharp
 public class ViewModel : INotifyPropertyChanged

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -112,9 +112,9 @@ When the `Order` property is set to `Secondary`, behavior varies across platform
 > [!WARNING]
 > Icon behavior in `ToolbarItem` objects that have their `Order` property set to `Secondary` is inconsistent across platforms. Avoid setting the `IconImageSource` property on items that appear in the secondary menu.
 
-## Enable or disable a ToolbarItem
+## Enable or disable a ToolbarItem dynamically
 
-To manipulate whether a `ToolbarItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
+To dynamically manipulate whether a `ToolbarItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
 
 For example, create a `ToolbarItem` on a `ContentPage` and bind its `Command` property in XAML:
 

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -97,6 +97,12 @@ void OnItemClicked(object sender, EventArgs e)
 
 `ToolbarItem` objects can also use the `Command` and `CommandParameter` properties to react to user input without event handlers. For more information about the `ICommand` interface and MVVM data-binding, see [Xamarin.Forms MenuItem MVVM Behavior](~/xamarin-forms/user-interface/menuitem.md#define-menuitem-behavior-with-mvvm).
 
+## Enable or disable a ToolbarItem at runtime
+
+To enable of disable a `ToolbarItem` at runtime, bind its `Command` property to an `ICommand` implementation, and ensure that a `canExecute` delegate enables and disables the `ICommand` as appropriate.
+
+For more information, see [Enable or disable a MenuItem at runtime](menuitem.md#enable-or-disable-a-menuitem-at-runtime).
+
 ## Primary and secondary menus
 
 The `ToolbarItemOrder` enum has `Default`, `Primary`, and `Secondary` values.
@@ -111,49 +117,6 @@ When the `Order` property is set to `Secondary`, behavior varies across platform
 
 > [!WARNING]
 > Icon behavior in `ToolbarItem` objects that have their `Order` property set to `Secondary` is inconsistent across platforms. Avoid setting the `IconImageSource` property on items that appear in the secondary menu.
-
-## Enable or disable a ToolbarItem dynamically
-
-To dynamically manipulate whether a `ToolbarItem` can respond to user interaction, use the bound `Command` property's `canExecute` delegate to return `true` or `false`.
-
-For example, create a `ToolbarItem` on a `ContentPage` and bind its `Command` property in XAML:
-
-```xaml
-<ContentPage.ToolbarItems>
-    <ToolbarItem Command="{Binding ToolbarTappedCommand}" Icon="icon.png" />
-</ContentPage.ToolbarItems>
-```
-
-In the view model, when implementing the `Command`, set a delegate for its `canExecute` parameter to return a `bool` property indicating whether to enable (`true`) or disable (`false`) the `ToolbarItem`:
-
-```csharp
-public class ViewModel : INotifyPropertyChanged
-{
-//...
-    public ICommand ToolbarTappedCommand { get; set; }
-    
-    private bool _enabled;
-    public bool Enabled
-    {
-        get => _enabled;
-        set
-        {
-            _enabled = value;
-            ToolbarTappedCommand.ChangeCanExecute();
-        }
-    }
-    
-    public ViewModel()
-    {
-        ToolbarTappedCommand = new Command(() =>
-        {
-            // your command behavior here
-        }, () => Enabled);
-        // ...
-    }
-```
-
-In this example, the `Enabled` property's default return value of `false` will initially set the `ToolbarItem` as disabled. Setting it to an initial value of `true` will initially enable the `ToolbarItem`.
 
 ## Related links
 

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -145,10 +145,10 @@ public class ViewModel : INotifyPropertyChanged
     
     public ViewModel()
     {
-        ToolbarTappedCommand = new Command((_) =>
+        ToolbarTappedCommand = new Command(() =>
         {
             // your command behavior here
-        }, (_) => Enabled);
+        }, () => Enabled);
         // ...
     }
 ```

--- a/docs/xamarin-forms/user-interface/toolbaritem.md
+++ b/docs/xamarin-forms/user-interface/toolbaritem.md
@@ -112,6 +112,49 @@ When the `Order` property is set to `Secondary`, behavior varies across platform
 > [!WARNING]
 > Icon behavior in `ToolbarItem` objects that have their `Order` property set to `Secondary` is inconsistent across platforms. Avoid setting the `IconImageSource` property on items that appear in the secondary menu.
 
+## Enable or Disable a ToolbarItem
+
+The [`IsEnabled`](xref:Xamarin.Forms.MenuItem.IsEnabled) property inherited from [`MenuItem`](xref:Xamarin.Forms.MenuItem) is read-only, and should not be used to manipulate the enabled or disabled state of a `ToolbarItem`. Instead, use the `CanExecute` functionality of the command bound to the `Command` property of the `ToolbarItem`.
+
+For example, create a `ToolbarItem` on a `ContentPage` and bind its `Command` property in XAML:
+
+```xaml
+<ContentPage.ToolbarItems>
+    <ToolbarItem Command="{Binding ToolbarTappedCommand}" Icon="enabled" />
+</ContentPage.ToolbarItems>
+```
+
+In the view model, when implementing the `Command`, set a delegate for its `canExecute` parameter to a property returning `bool` indicating whether to enable (`true`) or disable (`false`) the `ToolbarItem`:
+
+```csharp
+public class ViewModel : INotifyPropertyChanged
+{
+//...
+    public ICommand ToolbarTappedCommand { get; set; }
+    
+    private bool _enabled;
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            _enabled = value;
+            ToolbarTappedCommand.ChangeCanExecute();
+        }
+    }
+    
+    public ViewModel()
+    {
+        ToolbarTappedCommand = new Command((_) =>
+        {
+            // your command behavior here
+        }, (_) => Enabled);
+        // ...
+    }
+```
+
+The `Enabled` property's default return value of `false` will initially set the `ToolbarItem` as disabled.
+
 ## Related links
 
 * [ToolbarItem Demos](https://docs.microsoft.com/samples/xamarin/xamarin-forms-samples/userinterface-toolbaritem/)


### PR DESCRIPTION
There has been some confusion when using Xamarin.Forms around how to specify whether a `ToolbarItem` is enabled or disabled. This has changed in recent versions and it is not clear how to do this anymore. This is an attempt to clarify how to do this, including an example.

`ToolbarItem` inherits much of its functionality from `MenuItem` therefore that article was updated as well.