### PR TITLE
Should keep referring to the example button as myButton

### DIFF
--- a/docs/ios/user-interface/controls/buttons.md
+++ b/docs/ios/user-interface/controls/buttons.md
@@ -70,7 +70,7 @@ To respond to a button tap, provide a handler for the button's
 `TouchUpInside` event:
 
 ```csharp
-button.TouchUpInside += (sender, e) => {
+myButton.TouchUpInside += (sender, e) => {
     DoSomething();
 };
 ```
@@ -107,8 +107,8 @@ For example, to set the title color and shadow color for
 `UIControlState.Normal`:
 
 ```csharp
-button.SetTitleColor(UIColor.White, UIControlState.Normal);
-button.SetTitleShadowColor(UIColor.Black, UIControlState.Normal);
+myButton.SetTitleColor(UIColor.White, UIControlState.Normal);
+myButton.SetTitleShadowColor(UIColor.Black, UIControlState.Normal);
 ```
 
 The following code sets the button title to an attributed (stylized) string 
@@ -129,9 +129,9 @@ it's possible to configure the button's appearance by setting an image for
 its different states:
 
 ```csharp
-button4.SetImage (UIImage.FromBundle ("Buttons/MagicWand.png"), UIControlState.Normal);
-button4.SetImage (UIImage.FromBundle ("Buttons/MagicWand_Highlight.png"), UIControlState.Highlighted);
-button4.SetImage (UIImage.FromBundle ("Buttons/MagicWand_On.png"), UIControlState.Selected);
+myButton.SetImage (UIImage.FromBundle ("Buttons/MagicWand.png"), UIControlState.Normal);
+myButton.SetImage (UIImage.FromBundle ("Buttons/MagicWand_Highlight.png"), UIControlState.Highlighted);
+myButton.SetImage (UIImage.FromBundle ("Buttons/MagicWand_On.png"), UIControlState.Selected);
 ```
 
 Depending on whether the user is touching the button or not, it will


### PR DESCRIPTION
The example button is most of the time called myButton but it is later called just button or button4.
I'd recommend always calling it myButton consistently on this page