### PR TITLE
Wrong Sample on OpenBrowser

### DIFF
--- a/docs/essentials/open-browser.md
+++ b/docs/essentials/open-browser.md
@@ -30,9 +30,9 @@ The Browser functionality works by calling the `OpenAsync` method with the `Uri`
 
 public class BrowserTest
 {
-    public async Task<bool> OpenBrowser(Uri uri)
+    public async Task OpenBrowser(Uri uri)
     {
-        return await Browser.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
+        await Browser.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
     }
 }
 ```


### PR DESCRIPTION
[OpenAsync(String, BrowserLaunchMode) ](https://docs.microsoft.com/en-us/dotnet/api/xamarin.essentials.browser.openasync?view=xamarin-essentials#Xamarin_Essentials_Browser_OpenAsync_System_String_Xamarin_Essentials_BrowserLaunchMode_) don't return Tast<bool>


```csharp
public static System.Threading.Tasks.Task OpenAsync (string uri, Xamarin.Essentials.BrowserLaunchMode launchMode);
```
