### PR TITLE
Grammar corrections, added note

### DIFF
--- a/docs/android/deploy-test/signing/index.md
+++ b/docs/android/deploy-test/signing/index.md
@@ -75,12 +75,11 @@ For example, using **chimp** as the alias, the above steps would create a new si
 key in the following location:
 
 **C:\\Users\\*USERNAME*\\AppData\\Local\\Xamarin\\Mono for Android\\Keystore\\chimp\\chimp.keystore**
-> [!NOTE]
-> The AppData folder is hidden by default. You may need to unhide it to access it. To unhide hidden folders in file explorer 
-> select *View*, and in the *Show/Hide* section check the box for *File name extensions*.
 
-> [!NOTE]
-> Be sure to back up the resulting keystore file and password in a
+> [!IMPORTANT]
+> The AppData folder is hidden by default and you may need to unhide it to access it.
+>
+> In addition, be sure to back up the resulting keystore file and password in a
 > safe place &ndash; it is not included in the Solution. If you lose your
 > keystore file (for example, because you moved to another computer or
 > reinstalled Windows), you will be unable to

--- a/docs/android/deploy-test/signing/index.md
+++ b/docs/android/deploy-test/signing/index.md
@@ -12,7 +12,7 @@ ms.date: 07/02/2018
 # Signing the Android Application Package
 
 In [Preparing an App for Release](~/android/deploy-test/release-prep/index.md)
-the **Archive Manager** was used to build the app and place it in an archive for
+the **Archive Manager** can be used to build the app and place it in an archive for
 signing and publishing. This section explains how to create an Android
 signing identity, create a new signing certificate for Android
 applications, and publish the archived app *ad hoc* to disk. The
@@ -22,7 +22,7 @@ through an app store.
 # [Visual Studio](#tab/windows)
 
 In [Archive for Publishing](~/android/deploy-test/release-prep/index.md#archive),
-the **Distribution Channel** dialog presented two choices for
+the **Distribution Channel** dialog presents two choices for
 distribution. Select **Ad-Hoc**:
 
 [![Distribution Channel dialog](images/vs/01-distribution-channel-sml.png)](images/vs/01-distribution-channel.png#lightbox)
@@ -57,7 +57,7 @@ An existing certificate can be used by clicking the **Import** button and then p
 [![Ad Hoc signing identity](images/vs/02-ad-hoc-signing-identity-vs-sml.png)](images/vs/02-ad-hoc-signing-identity-vs.png#lightbox)
 
 The **Create Android Key Store** dialog is displayed; use this dialog
-to create a new signing certificate that can use for signing
+to create a new signing certificate that can be used for signing
 Android applications. Enter the required information (outlined in red)
 as shown in this dialog:
 
@@ -75,6 +75,9 @@ For example, using **chimp** as the alias, the above steps would create a new si
 key in the following location:
 
 **C:\\Users\\*USERNAME*\\AppData\\Local\\Xamarin\\Mono for Android\\Keystore\\chimp\\chimp.keystore**
+> [!NOTE]
+> The AppData folder is hidden by default. You may need to unhide it to access it. To unhide hidden folders in file explorer 
+> select *View*, and in the *Show/Hide* section check the box for *File name extensions*.
 
 > [!NOTE]
 > Be sure to back up the resulting keystore file and password in a

--- a/docs/android/deploy-test/signing/index.md
+++ b/docs/android/deploy-test/signing/index.md
@@ -12,7 +12,7 @@ ms.date: 07/02/2018
 # Signing the Android Application Package
 
 In [Preparing an App for Release](~/android/deploy-test/release-prep/index.md)
-the **Archive Manager** can be used to build the app and place it in an archive for
+the **Archive Manager** was used to build the app and place it in an archive for
 signing and publishing. This section explains how to create an Android
 signing identity, create a new signing certificate for Android
 applications, and publish the archived app *ad hoc* to disk. The


### PR DESCRIPTION
Before: "the Archive Manager was used to build the app and place it in an archive for signing and publishing"
This is confusing because it gives the reader the impression this was something done in the past but is no longer in practice.
After: "the Archive Manager can be used to build an app and place it in an archive for signing and publishing"
Before: "In Archive for Publishing, the Distribution Channel dialog presented two choices for distribution."
After: "In Archive for Publishing, the Distribution Channel dialog presents two choices for distribution."
Before: "use this dialog to create a new signing certificate that can use for signing Android applications"
After: "use this dialog to create a new signing certificate that can be used for signing Android applications"

Noted that the AppData folder is hidden by default and included instructions for how to unhide it if needed.