### PR TITLE
Remove <a/> links from build-process.md

### DIFF
--- a/docs/android/deploy-test/building-apps/build-process.md
+++ b/docs/android/deploy-test/building-apps/build-process.md
@@ -46,8 +46,6 @@ Debug package to be smaller.
 The shared runtime may be disabled in Debug builds by setting the
 `$(AndroidUseSharedRuntime)` property to `False`.
 
-<a name="Fast_Deployment" />
-
 ### Fast Deployment
 
 *Fast deployment* works in concert with the shared runtime to further
@@ -78,8 +76,6 @@ the build process is customizable by editing the project file directly.
 This page documents only the Xamarin.Android-specific features and
 customizations &ndash; many more things are possible with the normal
 MSBuild items, properties and targets.
-
-<a name="Build_Targets" />
 
 ## Build Targets
 


### PR DESCRIPTION
The [Xamarin.Android Build Process page](https://docs.microsoft.com/en-us/xamarin/android/deploy-test/building-apps/build-process) has entire sections (Fast Deployment onwards) showing as hyperlinks from what appears to be some extra <a/> tags in the markdown file. This continues until it hits a markdown link within the "Build Extension Points" section