### PR TITLE
Correction to the sample code on menuitem.md

### DIFF
--- a/docs/xamarin-forms/user-interface/menuitem.md
+++ b/docs/xamarin-forms/user-interface/menuitem.md
@@ -231,7 +231,7 @@ public class MyViewModel : INotifyPropertyChanged
         {
             // Execute logic here
         },
-        () => IsToolbarItemEnabled);
+        () => IsMenuItemEnabled);
     }
 }
 ```


### PR DESCRIPTION
In the sample code for the 'Enable or disable a MenuItem at runtime' section, the canExecute delegate was using IsToolbarItemEnabled instead of IsMenuItemEnabled.