### PR TITLE
Fix automatic provisioning link

### DIFF
--- a/docs/ios/get-started/installation/device-provisioning/automatic-provisioning.md
+++ b/docs/ios/get-started/installation/device-provisioning/automatic-provisioning.md
@@ -20,7 +20,7 @@ Automatic provisioning is available on Visual Studio for Mac, Visual Studio 2019
 
 > [!NOTE]
 > You must also have a paid Apple Developer account to use this feature. More information on Apple developer accounts is available in the [Device Provisioning](~/ios/get-started/installation/device-provisioning/index.md) guide.
-> If you do not have a paid Apple developer account, see the [Free Provisioning for Xamarin.iOS] (~/ios/get-started/installation/device-provisioning/free-provisioning.md) guide.
+> If you do not have a paid Apple developer account, see the [Free Provisioning for Xamarin.iOS](~/ios/get-started/installation/device-provisioning/free-provisioning.md) guide.
 
 > [!NOTE]
 > Before you begin, be sure to first accept any license agreements in either the [Apple Developer portal](https://developer.apple.com/account/) or [App Store Connect](https://appstoreconnect.apple.com/).


### PR DESCRIPTION
There was a space in the Markdown that caused the link to not be a link.