### PR TITLE
Fix typo in android camera permission name in docs

### DIFF
--- a/docs/essentials/media-picker.md
+++ b/docs/essentials/media-picker.md
@@ -32,7 +32,7 @@ Open the **AssemblyInfo.cs** file under the **Properties** folder and add:
 
 // Needed for Taking photo/video
 [assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]
-[assembly: UsesPermission(Android.Manifest.Permission.CameraExternalStorage)]
+[assembly: UsesPermission(Android.Manifest.Permission.Camera)]
 
 // Add these properties if you would like to filter out cameras that do not have cameras or set to false to make them optional
 [assembly: UsesFeature("android.hardware.camera", Required = true)]


### PR DESCRIPTION
Possible copy/paste error I reckon. 