### PR TITLE
Use correct extension class name in XAML

### DIFF
--- a/docs/xamarin-forms/user-interface/images.md
+++ b/docs/xamarin-forms/user-interface/images.md
@@ -196,7 +196,7 @@ public class ImageResourceExtension : IMarkupExtension
 > [!NOTE]
 > To support displaying embedded images in release mode on the Universal Windows Platform, it's necessary to use the overload of `ImageSource.FromResource` that specifies the source assembly in which to search for the image.
 
-To use this extension add a custom `xmlns` to the XAML, using the correct namespace and assembly values for the project. The image source can then be set using this syntax: `{local:ImageResource WorkingWithImages.beach.jpg}`. A complete XAML example is shown below:
+To use this extension add a custom `xmlns` to the XAML, using the correct namespace and assembly values for the project. The image source can then be set using this syntax: `{local:ImageResourceExtension WorkingWithImages.beach.jpg}`. A complete XAML example is shown below:
 
 ```xaml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -207,7 +207,7 @@ To use this extension add a custom `xmlns` to the XAML, using the correct namesp
    x:Class="WorkingWithImages.EmbeddedImagesXaml">
  <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
    <!-- use a custom Markup Extension -->
-   <Image Source="{local:ImageResource WorkingWithImages.beach.jpg}" />
+   <Image Source="{local:ImageResourceExtension WorkingWithImages.beach.jpg}" />
  </StackLayout>
 </ContentPage>
 ```


### PR DESCRIPTION
The document shows code on how to create an extension that can be used in XAML to work with images embedded resources. But the XAML syntax is not using the correct extension class name, like the one created in the code snippet above.

This PR fixes that.