### PR TITLE
Fixed casing in code example

### DIFF
--- a/docs/ios/platform/exception-marshaling.md
+++ b/docs/ios/platform/exception-marshaling.md
@@ -48,7 +48,7 @@ Consider the following code example:
 
 ``` csharp
 var dict = new NSMutableDictionary ();
-dict.LowLevelSetObject (IntPtr.Zero, IntPtr.Zero); 
+dict.LowlevelSetObject (IntPtr.Zero, IntPtr.Zero); 
 ```
 
 This will throw an Objective-C NSInvalidArgumentException in native code:


### PR DESCRIPTION
I tested the code example with the latest Xamarin.iOS version: Xamarin.iOS Version: 14.6.0.15 (Visual Studio Community)