### PR TITLE
Fast deploy fails for system apps

### DIFF
--- a/docs/android/deploy-test/building-apps/build-process.md
+++ b/docs/android/deploy-test/building-apps/build-process.md
@@ -70,6 +70,9 @@ Only the updated assemblies are resynchronized to the target device.
 
 > [!WARNING]
 > Fast deployment is known to fail on devices which block `run-as`, which often includes devices older than Android 5.0.
+> Fast deployment also fails for system applications (android:sharedUserId="android.uid.system") since `run-as` is also 
+> blocked for system applications.
+ 
 
 Fast deployment is enabled by default, and may be disabled in Debug builds
 by setting the `$(EmbedAssembliesIntoApk)` property to `True`.


### PR DESCRIPTION
Note indicating that fast deploy fails for system applications since run-as is blocked when UID=1001