### PR TITLE
Xamarin Essentials Platform Extensions title in table of contents consistent with article header

### DIFF
--- a/docs/android/TOC.yml
+++ b/docs/android/TOC.yml
@@ -457,7 +457,7 @@
           href: ~/essentials/permissions.md?context=xamarin/android
         - name: Phone Dialer
           href: ~/essentials/phone-dialer.md?context=xamarin/android
-        - name: Platform Extensions(Size, Rect, Point)
+        - name: Platform Extensions
           href: ~/essentials/platform-extensions.md?context=xamarin/android
         - name: Preferences
           href: ~/essentials/preferences.md?context=xamarin/android

--- a/docs/ios/TOC.yml
+++ b/docs/ios/TOC.yml
@@ -576,7 +576,7 @@
           href: ~/essentials/permissions.md?context=xamarin/ios
         - name: Phone Dialer
           href: ~/essentials/phone-dialer.md?context=xamarin/ios
-        - name: Platform Extensions(Size, Rect, Point)
+        - name: Platform Extensions
           href: ~/essentials/platform-extensions.md?context=xamarin/ios
         - name: Preferences
           href: ~/essentials/preferences.md?context=xamarin/ios
@@ -993,7 +993,7 @@
               href: ~/essentials/orientation-sensor.md?context=xamarin/watchos
             - name: Permissions
               href: ~/essentials/permissions.md?context=xamarin/watchos
-            - name: Platform Extensions(Size, Rect, Point)
+            - name: Platform Extensions
               href: ~/essentials/platform-extensions.md?context=xamarin/watchos
             - name: Preferences
               href: ~/essentials/preferences.md?context=xamarin/watchos
@@ -1088,7 +1088,7 @@
               href: ~/essentials/main-thread.md?context=xamarin/tvos
             - name: Permissions
               href: ~/essentials/permissions.md?context=xamarin/tvos
-            - name: Platform Extensions(Size, Rect, Point)
+            - name: Platform Extensions
               href: ~/essentials/platform-extensions.md?context=xamarin/tvos
             - name: Preferences
               href: ~/essentials/preferences.md?context=xamarin/tvos

--- a/docs/xamarin-forms/TOC.yml
+++ b/docs/xamarin-forms/TOC.yml
@@ -870,7 +870,7 @@
           href: ~/essentials/permissions.md?context=xamarin/xamarin-forms
         - name: Phone Dialer
           href: ~/essentials/phone-dialer.md?context=xamarin/xamarin-forms
-        - name: Platform Extensions(Size, Rect, Point)
+        - name: Platform Extensions
           href: ~/essentials/platform-extensions.md?context=xamarin/xamarin-forms
         - name: Preferences
           href: ~/essentials/preferences.md?context=xamarin/xamarin-forms


### PR DESCRIPTION
I propose this change to make article title in table of contents consistent with article header.
I think it also makes Platform Extensions functionality less misleading to documentation users, because it's now wider than Size, Rect and Point cross-platform converters.