### PR TITLE
Add x:Name for accessing the Text property

### DIFF
--- a/docs/xamarin-forms/user-interface/text/editor.md
+++ b/docs/xamarin-forms/user-interface/text/editor.md
@@ -21,7 +21,7 @@ The [`Editor`](xref:Xamarin.Forms.Editor) control is used to accept multi-line i
 The [`Editor`](xref:Xamarin.Forms.Editor), like other text-presenting views, exposes the `Text` property. This property can be used to set and read the text presented by the `Editor`. The following example demonstrates setting the `Text` property in XAML:
 
 ```xaml
-<Editor Text="I am an Editor" />
+<Editor x:Name="MyEditor" Text="I am an Editor" />
 ```
 
 In C#:

--- a/docs/xamarin-forms/user-interface/text/editor.md
+++ b/docs/xamarin-forms/user-interface/text/editor.md
@@ -21,19 +21,19 @@ The [`Editor`](xref:Xamarin.Forms.Editor) control is used to accept multi-line i
 The [`Editor`](xref:Xamarin.Forms.Editor), like other text-presenting views, exposes the `Text` property. This property can be used to set and read the text presented by the `Editor`. The following example demonstrates setting the `Text` property in XAML:
 
 ```xaml
-<Editor x:Name="MyEditor" Text="I am an Editor" />
+<Editor x:Name="editor" Text="I am an Editor" />
 ```
 
 In C#:
 
 ```csharp
-var MyEditor = new Editor { Text = "I am an Editor" };
+var editor = new Editor { Text = "I am an Editor" };
 ```
 
 To read text, access the `Text` property in C#:
 
 ```csharp
-var text = MyEditor.Text;
+var text = editor.Text;
 ```
 
 ## Set placeholder text

--- a/docs/xamarin-forms/user-interface/text/entry.md
+++ b/docs/xamarin-forms/user-interface/text/entry.md
@@ -21,7 +21,7 @@ The Xamarin.Forms [`Entry`](xref:Xamarin.Forms.Entry) is used for single-line te
 The `Entry`, like other text-presenting views, exposes the [`Text`](xref:Xamarin.Forms.InputView.Text) property. This property can be used to set and read the text presented by the `Entry`. The following example demonstrates setting the `Text` property in XAML:
 
 ```xaml
-<Entry Text="I am an Entry" />
+<Entry x:Name="MyEntry" Text="I am an Entry" />
 ```
 
 In C#:

--- a/docs/xamarin-forms/user-interface/text/entry.md
+++ b/docs/xamarin-forms/user-interface/text/entry.md
@@ -21,19 +21,19 @@ The Xamarin.Forms [`Entry`](xref:Xamarin.Forms.Entry) is used for single-line te
 The `Entry`, like other text-presenting views, exposes the [`Text`](xref:Xamarin.Forms.InputView.Text) property. This property can be used to set and read the text presented by the `Entry`. The following example demonstrates setting the `Text` property in XAML:
 
 ```xaml
-<Entry x:Name="MyEntry" Text="I am an Entry" />
+<Entry x:Name="entry" Text="I am an Entry" />
 ```
 
 In C#:
 
 ```csharp
-var MyEntry = new Entry { Text = "I am an Entry" };
+var entry = new Entry { Text = "I am an Entry" };
 ```
 
 To read text, access the `Text` property in C#:
 
 ```csharp
-var text = MyEntry.Text;
+var text = entry.Text;
 ```
 
 ## Set placeholder text


### PR DESCRIPTION
The example shows how to read the text of the entry. However it only works for C# but not XAML because the XAML entry element is not named.
My suggestion is to add x:Name attribute so that the code works for both C# and XAML.