### PR TITLE
Xamarin.Essentials: iOS Specific Info About Share Photos

### DIFF
--- a/docs/essentials/share.md
+++ b/docs/essentials/share.md
@@ -1,6 +1,6 @@
 ---
 title: "Xamarin.Essentials: Share"
-description: "The Share class in Xamarin.Essentials enables an application to share data such as text and web links to other applications on the device."
+description: "The Share class in Xamarin.Essentials enables an application to share data such as text, files and web links to other applications on the device."
 ms.assetid: B7B01D55-0129-4C87-B515-89F8F4E94665
 author: jamesmontemagno
 ms.author: jamont
@@ -16,6 +16,27 @@ The **Share** class enables an application to share data such as text and web li
 ## Get started
 
 [!include[](~/essentials/includes/get-started.md)]
+
+# [iOS](#tab/ios)
+
+If your application assumes a share video and photo files, you must add the following keys in your `Info.plist`:
+
+```xml
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>This app needs access to the photo gallery for saving photos and videos.</string>
+<key>NSPhotoLibraryUsageDescription</key>
+<string>This app needs access to photos gallery for saving photos and videos.</string>
+```
+
+Ensure that you update the `<string>` in each to a description specific for your app as it will be shown to your users.
+
+# [Android](#tab/android)
+
+No additional setup required.
+
+# [UWP](#tab/uwp)
+
+No additional setup required.
 
 ## Using Share
 

--- a/docs/essentials/share.md
+++ b/docs/essentials/share.md
@@ -1,6 +1,6 @@
 ---
 title: "Xamarin.Essentials: Share"
-description: "The Share class in Xamarin.Essentials enables an application to share data such as text, files and web links to other applications on the device."
+description: "The Share class in Xamarin.Essentials enables an application to share data such as text, files, and web links to other applications on the device."
 ms.assetid: B7B01D55-0129-4C87-B515-89F8F4E94665
 author: jamesmontemagno
 ms.author: jamont
@@ -19,7 +19,7 @@ The **Share** class enables an application to share data such as text and web li
 
 # [iOS](#tab/ios)
 
-If your application assumes a share video and photo files, you must add the following keys in your `Info.plist`:
+If your application shares media files, you must add the following keys to your `Info.plist`:
 
 ```xml
 <key>NSPhotoLibraryAddUsageDescription</key>
@@ -28,7 +28,7 @@ If your application assumes a share video and photo files, you must add the foll
 <string>This app needs access to photos gallery for saving photos and videos.</string>
 ```
 
-Ensure that you update the `<string>` in each to a description specific for your app as it will be shown to your users.
+Ensure that you update the `<string>` in each to a text that's specific for your app, because it will be shown to your users.
 
 # [Android](#tab/android)
 


### PR DESCRIPTION
A application will be crushed if the user clicks the "Save image" button in "Share" window. 
This action assumes that the following keys will be in the `Info.plist`:
```xml
<key>NSPhotoLibraryAddUsageDescription</key>
<string>This app needs access to the photo gallery for saving photos and videos.</string>
<key>NSPhotoLibraryUsageDescription</key>
<string>This app needs access to photos gallery for saving photos and videos.</string>
```
Video Samples:
|______________| With Keys | Without Keys |______________|
|:----------------:|:---------:|:-------------:|:----------------:|
||![With](https://user-images.githubusercontent.com/59065470/124382996-e3eaf080-dcd2-11eb-8989-7bb5818960f3.mov)|![Without](https://user-images.githubusercontent.com/59065470/124383054-257b9b80-dcd3-11eb-9452-4ad05e8f896a.mov)||






