### PR TITLE
Update manually-uploading-the-apk.md

### DIFF
--- a/docs/android/deploy-test/publishing/publishing-to-google-play/manually-uploading-the-apk.md
+++ b/docs/android/deploy-test/publishing/publishing-to-google-play/manually-uploading-the-apk.md
@@ -15,7 +15,8 @@ version of Xamarin.Android is used) the APK must be manually uploaded
 through the [Google Play Developer Console](https://play.google.com/apps/publish).
 This guide explains the steps required for this process.
 
-**Please note this procedure is no longer possible to do. [Google Play Developer Console](https://play.google.com/apps/publish) now accept only AAB package.**
+> [!WARNING]
+> [Google Play Developer Console](https://play.google.com/apps/publish) now only accepts AAB packages.**
 
 ## Google Play Developer Console
 

--- a/docs/android/deploy-test/publishing/publishing-to-google-play/manually-uploading-the-apk.md
+++ b/docs/android/deploy-test/publishing/publishing-to-google-play/manually-uploading-the-apk.md
@@ -16,7 +16,7 @@ through the [Google Play Developer Console](https://play.google.com/apps/publish
 This guide explains the steps required for this process.
 
 > [!WARNING]
-> [Google Play Developer Console](https://play.google.com/apps/publish) now only accepts AAB packages.**
+> [Google Play Developer Console](https://play.google.com/apps/publish) now only accepts AAB packages.
 
 ## Google Play Developer Console
 

--- a/docs/android/deploy-test/publishing/publishing-to-google-play/manually-uploading-the-apk.md
+++ b/docs/android/deploy-test/publishing/publishing-to-google-play/manually-uploading-the-apk.md
@@ -15,6 +15,8 @@ version of Xamarin.Android is used) the APK must be manually uploaded
 through the [Google Play Developer Console](https://play.google.com/apps/publish).
 This guide explains the steps required for this process.
 
+**Please note this procedure is no longer possible to do. [Google Play Developer Console](https://play.google.com/apps/publish) now accept only AAB package.**
+
 ## Google Play Developer Console
 
 Once the APK has been compiled and the promotional assets prepared, the


### PR DESCRIPTION
Hi, I propose a change, which should be tied to another page not yet done, as for today Google Play only accept AAB bundle. For historical reason I don't think that page should be rewrite, but another page should be done in my own opinion to reflect the new procedure to follow.

Thanks