### PR TITLE
Added sample content of AndroidManifest.xml file

### DIFF
--- a/docs/android/deploy-test/debuggable-attribute.md
+++ b/docs/android/deploy-test/debuggable-attribute.md
@@ -18,13 +18,21 @@ JDWP can be configured by the value of the `android:debuggable` attribute in an 
 
 Create or open `AndroidManifext.xml` file, and set the `android:debuggable` attribute there. Take extra care not to ship your release build with debugging enabled.
 
+```xml
+ 	<application android:label="@string/app_name"
+               android:debuggable="true"
+               android:icon="@mipmap/appicon">
+    ...
+	</application>
+```
+
 ## Add an Application class attribute
 
 If your Xamarin.Android app has a class with an `[Application]` attribute, update the attribute to `[Application(Debuggable = true)]`. Set it to `false` to disable.
 
 ## Add an assembly attribute
 
-If your Xamarin.Android app does NOT already have an `[Application]` class attribute, add an assembly-level attribute `[assembly: Application(Debuggable=true)]` in a c# file. Set it to `false` to disable.
+If your Xamarin.Android app does NOT already have an `[Application]` class attribute, add an assembly-level attribute `[assembly: Application(Debuggable=true)]` in a c# file such as, `Properties\AssemblyInfo.cs`. Set it to `false` to disable.
 
 ## Summary
 
@@ -41,7 +49,7 @@ By default – if neither the `AndroidManifest.xml` nor the `ApplicationAttribu
 
 > [!WARNING]
 > The value of the `android:debuggable` attribute does NOT necessarily depend on the build configuration. It is possible for release builds to have the `android:debuggable` attribute set to true. If you use an attribute to set this value, you can choose to wrap the attribute in a compiler directive:
-> 
+>
 > ```csharp
 > #if DEBUG
 > [Application(Debuggable = true)]


### PR DESCRIPTION
Updated with a sample `AndroidManifest.xml` file content for using the debuggable attribute.