### PR TITLE
Update web-authenticator.md OpenUrl on iOS

### DIFF
--- a/docs/essentials/web-authenticator.md
+++ b/docs/essentials/web-authenticator.md
@@ -86,10 +86,7 @@ You will also need to override your `AppDelegate`'s `OpenUrl` and `ContinueUserA
 ```csharp
 public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
 {
-    if (Xamarin.Essentials.Platform.OpenUrl(app, url, options))
-        return true;
-
-    return base.OpenUrl(app, url, options);
+    return Xamarin.Essentials.Platform.OpenUrl(app, url, options);
 }
 
 public override bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)


### PR DESCRIPTION
Remove call to `base.OpenUrl(app, url, options);` given that it throws `Foundation.You_Should_Not_Call_base_In_This_Method` because it's an `optional` method on the `AppDelegate` ([docs](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application))