### PR TITLE
Added Xamarin.iOS version nuspec limitation

### DIFF
--- a/docs/cross-platform/app-fundamentals/nuget-manual.md
+++ b/docs/cross-platform/app-fundamentals/nuget-manual.md
@@ -70,6 +70,7 @@ To clarify:
 
 - **MonoAndroid403** matches Android 4.0.3 and newer (ie API level 15)
 - **Xamarin.iOS10** matches Xamarin.iOS 1.0 and newer
+   * _Warning: Only "Xamarin.iOS" and "Xamarin.iOS10" are valid, limiting the iOS version does not work._
 - **Xamarin.iOS1.0** also matches Xamarin.iOS 1.0 and newer
 
 ## PCL NuGets with Platform Dependencies


### PR DESCRIPTION
I confirmed that using "Xamarin.iOS90" OR "Xamarin.iOS9.0" results in the
assembly being omitted completely from the project consuming the .nupkg.

Confirmed the above with the following ENV:
* .NET SDK 5.0.407
* NuGet CLI 5.11.1.5
* Visual Studio for macOS 2019 8.10.22 (build 11)
* Xamarin.iOS Version: 15.8.0.3