### PR TITLE
Fixed a typo in the sample usage of IpaPackageDir

### DIFF
--- a/docs/ios/deploy-test/app-distribution/ipa-support.md
+++ b/docs/ios/deploy-test/app-distribution/ipa-support.md
@@ -200,7 +200,7 @@ For example, to output the **.ipa** file to the old default directory (as in Xam
         <MtouchTlsProvider>Default</MtouchTlsProvider>
         <PlatformTarget>x86&</PlatformTarget>
         <BuildIpa>true</BuildIpa>
-        <IpaPackageDir>$(OutputPath</IpaPackageDir>
+        <IpaPackageDir>$(OutputPath)</IpaPackageDir>
     </PropertyGroup>
     ```
 


### PR DESCRIPTION
Fixed a typo in the code sample of usage of IpaPackageDir value.