### PR TITLE
Add missing parameter to Android example

### DIFF
--- a/docs/essentials/web-authenticator.md
+++ b/docs/essentials/web-authenticator.md
@@ -42,7 +42,7 @@ Android requires an Intent Filter setup to handle your callback URI. This is eas
 ```csharp
 const string CALLBACK_SCHEME = "myapp";
 
-[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
+[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop, Exported = true)]
 [IntentFilter(new[] { Android.Content.Intent.ActionView },
     Categories = new[] { Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable },
     DataScheme = CALLBACK_SCHEME)]


### PR DESCRIPTION
The parameter is a compulsory requirement in Android 12 (Api 31) and fixes [this issue comment](https://github.com/dotnet/maui/issues/2702#issuecomment-1120328840)