### PR TITLE
Remove language around return

### DIFF
--- a/docs/essentials/open-browser.md
+++ b/docs/essentials/open-browser.md
@@ -76,7 +76,7 @@ public class BrowserTest
 }
 ```
 
-This method returns after the browser was _launched_ and not necessarily _closed_ by the user.  The `bool` result indicates whether the launching was successful or not.
+This method returns after the browser was _launched_ and not necessarily _closed_ by the user.
 
 ## Customization
 


### PR DESCRIPTION
The `Browser.OpenAsync` method only returns a `Task`, so there is no return value to evaluate afterwards.