### PR TITLE
Update objective-c-libraries.md

### DIFF
--- a/docs/cross-platform/macios/binding/objective-c-libraries.md
+++ b/docs/cross-platform/macios/binding/objective-c-libraries.md
@@ -272,7 +272,7 @@ attribute, like this:
 
 ```csharp
 // A static method, that takes no arguments
-[Static, Export ("refresh")]
+[Static, Export ("beep")]
 void Beep ();
 ```
 


### PR DESCRIPTION
Update name of export method name to match the actual method name. It looks like the chunk was copied from above and not all parts were updated correctly.