### PR TITLE
Additional samples of prohibited usage added

### DIFF
--- a/docs/ios/internals/api-design/nsobject-generics.md
+++ b/docs/ios/internals/api-design/nsobject-generics.md
@@ -137,7 +137,7 @@ class Foo: NSView
 
 }
 ```
-**Reason**: the registrar does not support such a scenario yet. Complete sample and additional details may be found in the folldwing issue https://github.com/xamarin/xamarin-macios/issues/15709
+**Reason**: the registrar doesn't support this scenario yet. For more information, see [this GitHub issues](https://github.com/xamarin/xamarin-macios/issues/15709).
 
 ### Instantiations of Generic Types from Objective-C
 

--- a/docs/ios/internals/api-design/nsobject-generics.md
+++ b/docs/ios/internals/api-design/nsobject-generics.md
@@ -110,6 +110,35 @@ class Generic<T, U> : NSObject where T: NSObject
 `MyMethod` is constrained to be an `NSObject`, the unconstrained
 type `U` is not part of the signature.
 
+**Bad**:
+
+```csharp
+class Generic<T> : NSObject
+{
+    public T Storage { get; }
+
+    public Generic(T value)
+    {
+        Storage = value;
+    }
+}
+
+[Register("Foo")]
+class Foo: NSView
+{
+    [Export("Test")]
+    public Generic<int> Test { get; set; } = new Generic<int>(22);
+
+    [Export("Test1")]
+    public Generic<object> Test1 { get; set; } = new Generic<object>(new object());
+
+    [Export("Test2")]
+    public Generic<NSObject> Test2 { get; set; } = new Generic<NSObject>(new NSObject());
+
+}
+```
+**Reason**: the registrar does not support such a scenario yet. Complete sample and additional details may be found in the folldwing issue https://github.com/xamarin/xamarin-macios/issues/15709
+
 ### Instantiations of Generic Types from Objective-C
 
 Instantiation of generic types from Objective-C is not


### PR DESCRIPTION
Added samples to cover scenario from the https://github.com/xamarin/xamarin-macios/issues/15709 issue. The current version of documentation isn't 100% clear because this case doesn't totally match. The additional samples intended to make the things 100% clear.