### PR TITLE
Typo fix - update to device styles article

### DIFF
--- a/docs/xamarin-forms/user-interface/styles/xaml/device.md
+++ b/docs/xamarin-forms/user-interface/styles/xaml/device.md
@@ -105,7 +105,7 @@ public class DeviceStylesPageCS : ContentPage
 }
 ```
 
-The [`Style`](xref:Xamarin.Forms.NavigableElement.Style) property of each [`Label`](xref:Xamarin.Forms.Label) instance is set to the appropriate property from the [`Devices.Styles`](xref:Xamarin.Forms.Device.Styles) class.
+The [`Style`](xref:Xamarin.Forms.NavigableElement.Style) property of each [`Label`](xref:Xamarin.Forms.Label) instance is set to the appropriate property from the [`Device.Styles`](xref:Xamarin.Forms.Device.Styles) class.
 
 ## Accessibility
 


### PR DESCRIPTION
Change (Devices.Styles) to (Device.Styles) in ([`Label`](xref:Xamarin.Forms.Label) instance is set to the appropriate property from the [`Device.Styles`](xref:Xamarin.Forms.Device.Styles) class.).

Note: last line shows change but it actually is not changed.