### PR TITLE
Issue-3460 Typo fix

### DIFF
--- a/docs/xamarin-forms/user-interface/graphics/skiasharp/basics/circle.md
+++ b/docs/xamarin-forms/user-interface/graphics/skiasharp/basics/circle.md
@@ -89,7 +89,7 @@ void OnCanvasViewPaintSurface(object sender, SKPaintSurfaceEventArgs args)
     SKPaint paint = new SKPaint
     {
         Style = SKPaintStyle.Stroke,
-        Color = Color.Red.ToSKColor(),
+        Color = Colors.Red.ToSKColor(),
         StrokeWidth = 25
     };
     ...


### PR DESCRIPTION
Fixed the typo for the Enum Color as it is Colors actually, see link to issue : https://github.com/MicrosoftDocs/xamarin-docs/issues/3460