### PR TITLE
Typo fix - update to configure CarouselView interaction article

### DIFF
--- a/docs/xamarin-forms/user-interface/carouselview/interaction.md
+++ b/docs/xamarin-forms/user-interface/carouselview/interaction.md
@@ -232,7 +232,7 @@ In this example, the `CurrentItem` property is set to the fourth item in the `Mo
 
 ## Preset the position
 
-The displayed item [`CarouselView`](xref:Xamarin.Forms.CarouselView) can be programmatically set by setting the `Position` property to the index of the item in the underlying collection. The following XAML example shows a `CarouselView` that sets the displayed item:
+The displayed item in a [`CarouselView`](xref:Xamarin.Forms.CarouselView) can be programmatically set by setting the `Position` property to the index of the item in the underlying collection. The following XAML example shows a `CarouselView` that sets the displayed item:
 
 ```xaml
 <CarouselView ItemsSource="{Binding Monkeys}"


### PR DESCRIPTION
Change (... displayed item CarouselView can be programmatically...) to (... displayed item in a CarouselView...).
Note: last sentence is not touched although it seems so.