### PR TITLE
Remove incorrect Java / C# comparison

### DIFF
--- a/docs/android/get-started/java-developers.md
+++ b/docs/android/get-started/java-developers.md
@@ -57,9 +57,6 @@ synchronization support.
 
 However, there are many differences between Java and C#. For example:
 
-- Java (as used on Android) does not support implicitly-typed local variables (C#
-    supports the `var` keyword).
-
 - In Java, you can pass parameters only by value, while in C# you can
     pass by reference as well as by value. (C# provides the `ref` and
     `out` keywords for passing parameters by reference; there is no


### PR DESCRIPTION
Java 10 added local implicitly typed variables via `var`.

Android supports Java 11 language features since Android Gradle Plugin 7.0 (2021) https://developer.android.com/studio/releases/past-releases#expandable-9