### PR TITLE
Typo fix - update to Xamarin.Essentials: phone dialer article

### DIFF
--- a/docs/essentials/phone-dialer.md
+++ b/docs/essentials/phone-dialer.md
@@ -38,7 +38,7 @@ No additional setup required.
 
 # [UWP](#tab/uwp)
 
-No platform differences.
+No additional setup required.
 
 -----
 


### PR DESCRIPTION
- Change (No platform differences.) to (No additional setup required.) of UWP in get started section.