### PR TITLE
Typo fix - update to Xamarin.Essentials: SMS article

### DIFF
--- a/docs/essentials/sms.md
+++ b/docs/essentials/sms.md
@@ -40,7 +40,7 @@ No additional setup required.
 
 # [UWP](#tab/uwp)
 
-No platform differences.
+No additional setup required.
 
 -----
 


### PR DESCRIPTION
Change (No platform differences.) to (No additional setup required.) of UWP in get started section.