### PR TITLE
Add "Select the target device for debugging"

### DIFF
--- a/docs/android/get-started/installation/set-up-device-for-development.md
+++ b/docs/android/get-started/installation/set-up-device-for-development.md
@@ -85,6 +85,10 @@ computer** to prevent requiring this prompt each time you connect the device.
 
 ![Google USB](set-up-device-for-development-images/trust-computer-for-usb-debugging.png)
 
+## Select the target device for debugging
+
+If Visual Studio's target device for debugging is not the one you just connected to, then select it from the dropdown in the Standard toolbar (View > Toolbars > Standard).
+
 ## Alternate connection via Wifi
 
 It is possible to connect an Android device to a computer without using a USB cable, over WiFi. This technique requires more effort but could be useful when the device is too far from the computer to remain constantly plugged-in via cable. 


### PR DESCRIPTION
For me, Visual Studio did not automatically switch the debug target to my physical Android device. It kept targeting the emulator. The Standard toolbar was not displayed. I tried but could not switch to my physical device using the menus. I floundered for a long time before finding the answer: displaying the Standard toolbar.