### PR TITLE
Typo fix - update to Xamarin.Essentials: accelerometer and Xamarin.Essentials: media picker articles

### DIFF
--- a/docs/essentials/accelerometer.md
+++ b/docs/essentials/accelerometer.md
@@ -78,7 +78,7 @@ Examples:
 
 - When the device lies flat on a table and is pushed on its left side toward the right, the x acceleration value is positive.
 
-- When the device lies flat on a table, the acceleration value is +1.00 G or (+9.81 m/s^2), which correspond to the acceleration of the device (0 m/s^2) minus the force of gravity (-9.81 m/s^2) and normalized as in G.
+- When the device lies flat on a table, the acceleration value is +1.00 G or (+9.81 m/s^2), which corresponds to the acceleration of the device (0 m/s^2) minus the force of gravity (-9.81 m/s^2) and normalized as in G.
 
 - When the device lies flat on a table and is pushed toward the sky with an acceleration of A m/s^2, the acceleration value is equal to A+9.81 which corresponds to the acceleration of the device (+A m/s^2) minus the force of gravity (-9.81 m/s^2) and normalized in G.
 

--- a/docs/essentials/media-picker.md
+++ b/docs/essentials/media-picker.md
@@ -47,7 +47,7 @@ Open the **AndroidManifest.xml** file under the **Properties** folder and add th
 <uses-permission android:name="android.permission.CAMERA" />
 ```
 
-Or right click on the Android project and open the project's properties. Under **Android Manifest** find the **Required permissions:** area and check the these permissions. This will automatically update the **AndroidManifest.xml** file.
+Or right click on the Android project and open the project's properties. Under **Android Manifest** find the **Required permissions:** area and check these permissions. This will automatically update the **AndroidManifest.xml** file.
 
 If your project's Target Android version is set to **Android 11 (R API 30)** you must update your Android Manifest with queries that are used with the new [package visibility requirements](https://developer.android.com/preview/privacy/package-visibility).
 


### PR DESCRIPTION
Change (... which correspond to the acceleration of the device...) to (... which corresponds...).