### PR TITLE
Update android-sdk.md empty bullet point

### DIFF
--- a/docs/android/get-started/installation/android-sdk.md
+++ b/docs/android/get-started/installation/android-sdk.md
@@ -34,13 +34,9 @@ replaces Google's standalone SDK Manager, which has been deprecated.
 
 To use the Xamarin Android SDK Manager, you will need the following:
 
-- Visual Studio 2022 Community, Professional, or Enterprise.
-- 
-- Visual Studio 2019 Community, Professional, or Enterprise.
-
+- Visual Studio (2022 or 2019) Community, Professional, or Enterprise.
 - OR Visual Studio 2017 (Community, Professional, or Enterprise edition). Visual
   Studio 2017 version 15.7 or later is required.
-
 - Visual Studio Tools for Xamarin version 4.10.0 or later
   (installed as part of the **Mobile development with .NET** workload). 
 


### PR DESCRIPTION
I noticed that the documentation included an extra bullet point that didn't contain any information. I removed it and added the Visual Studio versions in parentheses as either 2022 or 2019 as I believe this makes it easier to read. However, the most important change was removing the blank bullet point.