### PR TITLE
Fixed suggested code to disable debugging for release builds.

### DIFF
--- a/docs/android/deploy-test/release-prep/index.md
+++ b/docs/android/deploy-test/release-prep/index.md
@@ -291,10 +291,8 @@ considered a good practice to set the `android:debuggable` attribute to
 statement in **AssemblyInfo.cs**:
 
 ```csharp
-#if DEBUG
-[assembly: Application(Debuggable=true)]
-#else
-[assembly: Application(Debuggable=false)]
+#if !DEBUG
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.None)]
 #endif
 ```
 


### PR DESCRIPTION
The currently suggested code did not work for me. I had to make the following change to ensure debugging is disabled for release builds.

This is my first contribution. I read through the guidelines and couldn't see any violations, please let me know if I need to change anything.