### PR TITLE
Update healthkit.md code example to not add a bug

### DIFF
--- a/docs/ios/platform/healthkit.md
+++ b/docs/ios/platform/healthkit.md
@@ -170,6 +170,7 @@ private HKHealthStore healthKitStore = new HKHealthStore ();
 
 public override void OnActivated (UIApplication application)
 {
+        base.OnActivated(application);
         ValidateAuthorization ();
 }
 


### PR DESCRIPTION
adding call to base OnActivated, so that Window lifecycle in MAUI is maintained

leaving this out causes **System.InvalidOperationException:** 'Window was already deactivated' when app is minimized/reopened