### PR TITLE
build-properties.md: Note that AndroidLinkMode is legacy

### DIFF
--- a/docs/android/deploy-test/building-apps/build-properties.md
+++ b/docs/android/deploy-test/building-apps/build-properties.md
@@ -771,6 +771,11 @@ The Android activity to launch.
 
 ## AndroidLinkMode
 
+  > [!TIP]
+  > `AndroidLinkMode` is a legacy property. You should migrate to the
+  > new linker `PublishTrimmed` and `TrimMode` because the `AndroidLinkMode`
+  > setting will eventually be deprecated.
+
 Specifies which type of
 [linking](~/android/deploy-test/linker.md) should be
 performed on assemblies contained within the Android package. Only


### PR DESCRIPTION
Copied relative portions of the tip from [Android migration](https://raw.githubusercontent.com/dotnet/docs-maui/main/docs/migration/android-projects.md).